### PR TITLE
USB Device: revert USB descriptors back to main header for public access

### DIFF
--- a/Components/USB/Include/rl_usb.h
+++ b/Components/USB/Include/rl_usb.h
@@ -152,13 +152,31 @@ typedef enum {
 } usbdSemaphore_t;
 
 /* USB Device State structure */
-/// @cond USBD_STATE_cond
+/// @cond DOXYGEN_SKIP
 typedef struct {
   uint32_t vbus     :  1;               ///< USB Device VBUS state
   uint32_t speed    :  2;               ///< USB Device enumerated speed (USB_SPEED_LOW, USB_SPEED_FULL or USB_SPEED_HIGH)
   uint32_t active   :  1;               ///< USB Device bus activity
   uint32_t reserved : 28;               ///< reserved
 } USBD_STATE;
+/// @endcond
+
+/* USB Device Descriptors structure */
+/// @cond DOXYGEN_SKIP
+typedef struct {
+  const uint8_t *ep0_descriptor;                        ///< Pointer to Control Endpoint 0 descriptor
+  const uint8_t *device_descriptor;                     ///< Pointer to Device descriptor
+  const uint8_t *device_qualifier_fs;                   ///< Pointer to Device Qualifier for low/full-speed
+  const uint8_t *device_qualifier_hs;                   ///< Pointer to Device Qualifier for high-speed
+  const uint8_t *config_descriptor_fs;                  ///< Pointer to Configuration descriptor for low/full-speed
+  const uint8_t *config_descriptor_hs;                  ///< Pointer to Configuration descriptor for high-speed
+  const uint8_t *other_speed_config_descriptor_fs;      ///< Pointer to Other Speed Configuration descriptor for low/full-speed
+  const uint8_t *other_speed_config_descriptor_hs;      ///< Pointer to Other Speed Configuration descriptor for high-speed
+  const uint8_t *string_descriptor;                     ///< Pointer to String descriptors
+        uint8_t *ser_num_string_descriptor;             ///< Pointer to Serial Number String descriptor
+  const uint8_t *ms_os_string_descriptor;               ///< Pointer to Microsoft OS string descriptor
+  const uint8_t *ms_os_ext_compat_id_descriptor;        ///< Pointer to Microsoft Extended Compat ID OS Feature Descriptor 
+} usbd_desc_t;
 /// @endcond
 
 /* USB Host Constants and Defines */
@@ -1649,6 +1667,47 @@ extern usbStatus USBH_DeviceRequest_SetInterface (uint8_t device, uint8_t index,
 /// \param[out]    ptr_frame_number     pointer to where frame number data will be read.
 /// \return                             status code that indicates the execution status of the function as defined with \ref usbStatus.
 extern usbStatus USBH_DeviceRequest_SynchFrame (uint8_t device, uint8_t index, uint8_t *ptr_frame_number);
+
+// USB Device descriptors external declarations
+extern const uint8_t     usbd0_ep0_descriptor[];
+extern const uint8_t     usbd0_device_descriptor[];
+extern const uint8_t     usbd0_config_descriptor_fs[];
+extern const uint8_t     usbd0_config_descriptor_hs[];
+extern const uint8_t     usbd0_device_qualifier_fs[];
+extern const uint8_t     usbd0_device_qualifier_hs[];
+extern const uint8_t     usbd0_other_speed_config_descriptor_fs[];
+extern const uint8_t     usbd0_other_speed_config_descriptor_hs[];
+extern usbd_desc_t       usbd0_desc;
+
+extern const uint8_t     usbd1_ep0_descriptor[];
+extern const uint8_t     usbd1_device_descriptor[];
+extern const uint8_t     usbd1_config_descriptor_fs[];
+extern const uint8_t     usbd1_config_descriptor_hs[];
+extern const uint8_t     usbd1_device_qualifier_fs[];
+extern const uint8_t     usbd1_device_qualifier_hs[];
+extern const uint8_t     usbd1_other_speed_config_descriptor_fs[];
+extern const uint8_t     usbd1_other_speed_config_descriptor_hs[];
+extern usbd_desc_t       usbd1_desc;
+
+extern const uint8_t     usbd2_ep0_descriptor[];
+extern const uint8_t     usbd2_device_descriptor[];
+extern const uint8_t     usbd2_config_descriptor_fs[];
+extern const uint8_t     usbd2_config_descriptor_hs[];
+extern const uint8_t     usbd2_device_qualifier_fs[];
+extern const uint8_t     usbd2_device_qualifier_hs[];
+extern const uint8_t     usbd2_other_speed_config_descriptor_fs[];
+extern const uint8_t     usbd2_other_speed_config_descriptor_hs[];
+extern usbd_desc_t       usbd2_desc;
+
+extern const uint8_t     usbd3_ep0_descriptor[];
+extern const uint8_t     usbd3_device_descriptor[];
+extern const uint8_t     usbd3_config_descriptor_fs[];
+extern const uint8_t     usbd3_config_descriptor_hs[];
+extern const uint8_t     usbd3_device_qualifier_fs[];
+extern const uint8_t     usbd3_device_qualifier_hs[];
+extern const uint8_t     usbd3_other_speed_config_descriptor_fs[];
+extern const uint8_t     usbd3_other_speed_config_descriptor_hs[];
+extern usbd_desc_t       usbd3_desc;
 
 // USB Device user callback function prototypes
 extern void              USBD_Device0_Initialize            (void);

--- a/Components/USB/Script/Headers/usbd_config_desc_x.c
+++ b/Components/USB/Script/Headers/usbd_config_desc_x.c
@@ -1,17 +1,15 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    usbd_config_desc_$x.c
  * Purpose: USB Device $x Descriptor Creation
  *----------------------------------------------------------------------------*/
 
 /* USB Device $x Endpoint 0 Descriptor */
-extern const uint8_t usbd$x_ep0_descriptor[];
 __WEAK const uint8_t usbd$x_ep0_descriptor[] __ALIGNED(4) = { USBD_EP0($x) };
 
 /* USB Device $x Standard Descriptor */
-extern const uint8_t usbd$x_device_descriptor[];
 __WEAK const uint8_t usbd$x_device_descriptor[] __ALIGNED(4) = {
   USB_DEVICE_DESC_SIZE,                 /* bLength */
   USB_DEVICE_DESCRIPTOR_TYPE,           /* bDescriptorType */
@@ -42,7 +40,6 @@ __WEAK const uint8_t usbd$x_device_descriptor[] __ALIGNED(4) = {
 
 /* USB Device $x Configuration Descriptor (for Full Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd$x_config_descriptor_fs[];
 __WEAK const uint8_t usbd$x_config_descriptor_fs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -395,7 +392,6 @@ __WEAK const uint8_t usbd$x_config_descriptor_fs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD$x_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -932,15 +928,10 @@ __WEAK const uint8_t usbd$x_config_descriptor_fs[] __ALIGNED(4) = {
 };
 
 #if (!USBD$x_HS)                         /* If High-speed not enabled, declare dummy descriptors for High-speed */
-extern const uint8_t usbd$x_device_qualifier_fs[];
 __WEAK const uint8_t usbd$x_device_qualifier_fs[]              = { 0 };
-extern const uint8_t usbd$x_device_qualifier_hs[];
 __WEAK const uint8_t usbd$x_device_qualifier_hs[]              = { 0 };
-extern const uint8_t usbd$x_config_descriptor_hs[];
 __WEAK const uint8_t usbd$x_config_descriptor_hs[]             = { 0 };
-extern const uint8_t usbd$x_other_speed_config_descriptor_fs[];
 __WEAK const uint8_t usbd$x_other_speed_config_descriptor_fs[] = { 0 };
-extern const uint8_t usbd$x_other_speed_config_descriptor_hs[];
 __WEAK const uint8_t usbd$x_other_speed_config_descriptor_hs[] = { 0 };
 
 #else
@@ -950,7 +941,6 @@ __WEAK const uint8_t usbd$x_other_speed_config_descriptor_hs[] = { 0 };
 #endif
 
 /* USB Device $x Qualifier Descriptor (in Full Speed for High Speed) */
-extern const uint8_t usbd$x_device_qualifier_fs[];
 __WEAK const uint8_t usbd$x_device_qualifier_fs[] __ALIGNED(4) = {
   USB_DEVICE_QUALI_SIZE,                /* bLength */
   USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE, /* bDescriptorType */
@@ -964,7 +954,6 @@ __WEAK const uint8_t usbd$x_device_qualifier_fs[] __ALIGNED(4) = {
 };
 
 /* USB Device $x Qualifier Descriptor (in High Speed for Full Speed) */
-extern const uint8_t usbd$x_device_qualifier_hs[];
 __WEAK const uint8_t usbd$x_device_qualifier_hs[] __ALIGNED(4) = {
   USB_DEVICE_QUALI_SIZE,                /* bLength */
   USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE, /* bDescriptorType */
@@ -979,7 +968,6 @@ __WEAK const uint8_t usbd$x_device_qualifier_hs[] __ALIGNED(4) = {
 
 /* USB Device $x Configuration Descriptor (for High Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd$x_config_descriptor_hs[];
 __WEAK const uint8_t usbd$x_config_descriptor_hs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -1332,7 +1320,6 @@ __WEAK const uint8_t usbd$x_config_descriptor_hs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD$x_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -1721,7 +1708,6 @@ __WEAK const uint8_t usbd$x_config_descriptor_hs[] __ALIGNED(4) = {
 
 /* USB Device $x Other Speed Configuration Descriptor (in Full Speed for High Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd$x_other_speed_config_descriptor_fs[];
 __WEAK const uint8_t usbd$x_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -2002,7 +1988,6 @@ __WEAK const uint8_t usbd$x_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD$x_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -2367,7 +2352,6 @@ __WEAK const uint8_t usbd$x_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
 
 /* USB Device $x Other Speed Configuration Descriptor (in High Speed for Full Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd$x_other_speed_config_descriptor_hs[];
 __WEAK const uint8_t usbd$x_other_speed_config_descriptor_hs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -2648,7 +2632,6 @@ __WEAK const uint8_t usbd$x_other_speed_config_descriptor_hs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD$x_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -4227,10 +4210,7 @@ static const usbd$x_ms_os_ext_compat_id_descriptor_t usbd$x_ms_os_ext_compat_id_
 #endif // ((USBD$x_CUSTOM_CLASS_MS_COMPAT_CNT != 0) || (USBD$x_CDC_MS_COMPAT_CNT != 0))
 #endif // (USBD$x_OS_DESC_EN != 0)
 
-
 // Pointers to all descriptors
-extern 
-usbd_desc_t usbd$x_desc;
 usbd_desc_t usbd$x_desc = {
   usbd$x_ep0_descriptor,
   usbd$x_device_descriptor,

--- a/Components/USB/Source/usbd_config_desc_0.c
+++ b/Components/USB/Source/usbd_config_desc_0.c
@@ -1,17 +1,15 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    usbd_config_desc_0.c
  * Purpose: USB Device 0 Descriptor Creation
  *----------------------------------------------------------------------------*/
 
 /* USB Device 0 Endpoint 0 Descriptor */
-extern const uint8_t usbd0_ep0_descriptor[];
 __WEAK const uint8_t usbd0_ep0_descriptor[] __ALIGNED(4) = { USBD_EP0(0) };
 
 /* USB Device 0 Standard Descriptor */
-extern const uint8_t usbd0_device_descriptor[];
 __WEAK const uint8_t usbd0_device_descriptor[] __ALIGNED(4) = {
   USB_DEVICE_DESC_SIZE,                 /* bLength */
   USB_DEVICE_DESCRIPTOR_TYPE,           /* bDescriptorType */
@@ -42,7 +40,6 @@ __WEAK const uint8_t usbd0_device_descriptor[] __ALIGNED(4) = {
 
 /* USB Device 0 Configuration Descriptor (for Full Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd0_config_descriptor_fs[];
 __WEAK const uint8_t usbd0_config_descriptor_fs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -395,7 +392,6 @@ __WEAK const uint8_t usbd0_config_descriptor_fs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD0_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -932,15 +928,10 @@ __WEAK const uint8_t usbd0_config_descriptor_fs[] __ALIGNED(4) = {
 };
 
 #if (!USBD0_HS)                         /* If High-speed not enabled, declare dummy descriptors for High-speed */
-extern const uint8_t usbd0_device_qualifier_fs[];
 __WEAK const uint8_t usbd0_device_qualifier_fs[]              = { 0 };
-extern const uint8_t usbd0_device_qualifier_hs[];
 __WEAK const uint8_t usbd0_device_qualifier_hs[]              = { 0 };
-extern const uint8_t usbd0_config_descriptor_hs[];
 __WEAK const uint8_t usbd0_config_descriptor_hs[]             = { 0 };
-extern const uint8_t usbd0_other_speed_config_descriptor_fs[];
 __WEAK const uint8_t usbd0_other_speed_config_descriptor_fs[] = { 0 };
-extern const uint8_t usbd0_other_speed_config_descriptor_hs[];
 __WEAK const uint8_t usbd0_other_speed_config_descriptor_hs[] = { 0 };
 
 #else
@@ -950,7 +941,6 @@ __WEAK const uint8_t usbd0_other_speed_config_descriptor_hs[] = { 0 };
 #endif
 
 /* USB Device 0 Qualifier Descriptor (in Full Speed for High Speed) */
-extern const uint8_t usbd0_device_qualifier_fs[];
 __WEAK const uint8_t usbd0_device_qualifier_fs[] __ALIGNED(4) = {
   USB_DEVICE_QUALI_SIZE,                /* bLength */
   USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE, /* bDescriptorType */
@@ -964,7 +954,6 @@ __WEAK const uint8_t usbd0_device_qualifier_fs[] __ALIGNED(4) = {
 };
 
 /* USB Device 0 Qualifier Descriptor (in High Speed for Full Speed) */
-extern const uint8_t usbd0_device_qualifier_hs[];
 __WEAK const uint8_t usbd0_device_qualifier_hs[] __ALIGNED(4) = {
   USB_DEVICE_QUALI_SIZE,                /* bLength */
   USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE, /* bDescriptorType */
@@ -979,7 +968,6 @@ __WEAK const uint8_t usbd0_device_qualifier_hs[] __ALIGNED(4) = {
 
 /* USB Device 0 Configuration Descriptor (for High Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd0_config_descriptor_hs[];
 __WEAK const uint8_t usbd0_config_descriptor_hs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -1332,7 +1320,6 @@ __WEAK const uint8_t usbd0_config_descriptor_hs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD0_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -1721,7 +1708,6 @@ __WEAK const uint8_t usbd0_config_descriptor_hs[] __ALIGNED(4) = {
 
 /* USB Device 0 Other Speed Configuration Descriptor (in Full Speed for High Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd0_other_speed_config_descriptor_fs[];
 __WEAK const uint8_t usbd0_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -2002,7 +1988,6 @@ __WEAK const uint8_t usbd0_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD0_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -2367,7 +2352,6 @@ __WEAK const uint8_t usbd0_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
 
 /* USB Device 0 Other Speed Configuration Descriptor (in High Speed for Full Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd0_other_speed_config_descriptor_hs[];
 __WEAK const uint8_t usbd0_other_speed_config_descriptor_hs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -2648,7 +2632,6 @@ __WEAK const uint8_t usbd0_other_speed_config_descriptor_hs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD0_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -4227,10 +4210,7 @@ static const usbd0_ms_os_ext_compat_id_descriptor_t usbd0_ms_os_ext_compat_id_de
 #endif // ((USBD0_CUSTOM_CLASS_MS_COMPAT_CNT != 0) || (USBD0_CDC_MS_COMPAT_CNT != 0))
 #endif // (USBD0_OS_DESC_EN != 0)
 
-
 // Pointers to all descriptors
-extern 
-usbd_desc_t usbd0_desc;
 usbd_desc_t usbd0_desc = {
   usbd0_ep0_descriptor,
   usbd0_device_descriptor,

--- a/Components/USB/Source/usbd_config_desc_1.c
+++ b/Components/USB/Source/usbd_config_desc_1.c
@@ -1,17 +1,15 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    usbd_config_desc_1.c
  * Purpose: USB Device 1 Descriptor Creation
  *----------------------------------------------------------------------------*/
 
 /* USB Device 1 Endpoint 0 Descriptor */
-extern const uint8_t usbd1_ep0_descriptor[];
 __WEAK const uint8_t usbd1_ep0_descriptor[] __ALIGNED(4) = { USBD_EP0(1) };
 
 /* USB Device 1 Standard Descriptor */
-extern const uint8_t usbd1_device_descriptor[];
 __WEAK const uint8_t usbd1_device_descriptor[] __ALIGNED(4) = {
   USB_DEVICE_DESC_SIZE,                 /* bLength */
   USB_DEVICE_DESCRIPTOR_TYPE,           /* bDescriptorType */
@@ -42,7 +40,6 @@ __WEAK const uint8_t usbd1_device_descriptor[] __ALIGNED(4) = {
 
 /* USB Device 1 Configuration Descriptor (for Full Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd1_config_descriptor_fs[];
 __WEAK const uint8_t usbd1_config_descriptor_fs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -395,7 +392,6 @@ __WEAK const uint8_t usbd1_config_descriptor_fs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD1_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -932,15 +928,10 @@ __WEAK const uint8_t usbd1_config_descriptor_fs[] __ALIGNED(4) = {
 };
 
 #if (!USBD1_HS)                         /* If High-speed not enabled, declare dummy descriptors for High-speed */
-extern const uint8_t usbd1_device_qualifier_fs[];
 __WEAK const uint8_t usbd1_device_qualifier_fs[]              = { 0 };
-extern const uint8_t usbd1_device_qualifier_hs[];
 __WEAK const uint8_t usbd1_device_qualifier_hs[]              = { 0 };
-extern const uint8_t usbd1_config_descriptor_hs[];
 __WEAK const uint8_t usbd1_config_descriptor_hs[]             = { 0 };
-extern const uint8_t usbd1_other_speed_config_descriptor_fs[];
 __WEAK const uint8_t usbd1_other_speed_config_descriptor_fs[] = { 0 };
-extern const uint8_t usbd1_other_speed_config_descriptor_hs[];
 __WEAK const uint8_t usbd1_other_speed_config_descriptor_hs[] = { 0 };
 
 #else
@@ -950,7 +941,6 @@ __WEAK const uint8_t usbd1_other_speed_config_descriptor_hs[] = { 0 };
 #endif
 
 /* USB Device 1 Qualifier Descriptor (in Full Speed for High Speed) */
-extern const uint8_t usbd1_device_qualifier_fs[];
 __WEAK const uint8_t usbd1_device_qualifier_fs[] __ALIGNED(4) = {
   USB_DEVICE_QUALI_SIZE,                /* bLength */
   USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE, /* bDescriptorType */
@@ -964,7 +954,6 @@ __WEAK const uint8_t usbd1_device_qualifier_fs[] __ALIGNED(4) = {
 };
 
 /* USB Device 1 Qualifier Descriptor (in High Speed for Full Speed) */
-extern const uint8_t usbd1_device_qualifier_hs[];
 __WEAK const uint8_t usbd1_device_qualifier_hs[] __ALIGNED(4) = {
   USB_DEVICE_QUALI_SIZE,                /* bLength */
   USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE, /* bDescriptorType */
@@ -979,7 +968,6 @@ __WEAK const uint8_t usbd1_device_qualifier_hs[] __ALIGNED(4) = {
 
 /* USB Device 1 Configuration Descriptor (for High Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd1_config_descriptor_hs[];
 __WEAK const uint8_t usbd1_config_descriptor_hs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -1332,7 +1320,6 @@ __WEAK const uint8_t usbd1_config_descriptor_hs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD1_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -1721,7 +1708,6 @@ __WEAK const uint8_t usbd1_config_descriptor_hs[] __ALIGNED(4) = {
 
 /* USB Device 1 Other Speed Configuration Descriptor (in Full Speed for High Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd1_other_speed_config_descriptor_fs[];
 __WEAK const uint8_t usbd1_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -2002,7 +1988,6 @@ __WEAK const uint8_t usbd1_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD1_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -2367,7 +2352,6 @@ __WEAK const uint8_t usbd1_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
 
 /* USB Device 1 Other Speed Configuration Descriptor (in High Speed for Full Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd1_other_speed_config_descriptor_hs[];
 __WEAK const uint8_t usbd1_other_speed_config_descriptor_hs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -2648,7 +2632,6 @@ __WEAK const uint8_t usbd1_other_speed_config_descriptor_hs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD1_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -4227,10 +4210,7 @@ static const usbd1_ms_os_ext_compat_id_descriptor_t usbd1_ms_os_ext_compat_id_de
 #endif // ((USBD1_CUSTOM_CLASS_MS_COMPAT_CNT != 0) || (USBD1_CDC_MS_COMPAT_CNT != 0))
 #endif // (USBD1_OS_DESC_EN != 0)
 
-
 // Pointers to all descriptors
-extern 
-usbd_desc_t usbd1_desc;
 usbd_desc_t usbd1_desc = {
   usbd1_ep0_descriptor,
   usbd1_device_descriptor,

--- a/Components/USB/Source/usbd_config_desc_2.c
+++ b/Components/USB/Source/usbd_config_desc_2.c
@@ -1,17 +1,15 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    usbd_config_desc_2.c
  * Purpose: USB Device 2 Descriptor Creation
  *----------------------------------------------------------------------------*/
 
 /* USB Device 2 Endpoint 0 Descriptor */
-extern const uint8_t usbd2_ep0_descriptor[];
 __WEAK const uint8_t usbd2_ep0_descriptor[] __ALIGNED(4) = { USBD_EP0(2) };
 
 /* USB Device 2 Standard Descriptor */
-extern const uint8_t usbd2_device_descriptor[];
 __WEAK const uint8_t usbd2_device_descriptor[] __ALIGNED(4) = {
   USB_DEVICE_DESC_SIZE,                 /* bLength */
   USB_DEVICE_DESCRIPTOR_TYPE,           /* bDescriptorType */
@@ -42,7 +40,6 @@ __WEAK const uint8_t usbd2_device_descriptor[] __ALIGNED(4) = {
 
 /* USB Device 2 Configuration Descriptor (for Full Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd2_config_descriptor_fs[];
 __WEAK const uint8_t usbd2_config_descriptor_fs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -395,7 +392,6 @@ __WEAK const uint8_t usbd2_config_descriptor_fs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD2_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -932,15 +928,10 @@ __WEAK const uint8_t usbd2_config_descriptor_fs[] __ALIGNED(4) = {
 };
 
 #if (!USBD2_HS)                         /* If High-speed not enabled, declare dummy descriptors for High-speed */
-extern const uint8_t usbd2_device_qualifier_fs[];
 __WEAK const uint8_t usbd2_device_qualifier_fs[]              = { 0 };
-extern const uint8_t usbd2_device_qualifier_hs[];
 __WEAK const uint8_t usbd2_device_qualifier_hs[]              = { 0 };
-extern const uint8_t usbd2_config_descriptor_hs[];
 __WEAK const uint8_t usbd2_config_descriptor_hs[]             = { 0 };
-extern const uint8_t usbd2_other_speed_config_descriptor_fs[];
 __WEAK const uint8_t usbd2_other_speed_config_descriptor_fs[] = { 0 };
-extern const uint8_t usbd2_other_speed_config_descriptor_hs[];
 __WEAK const uint8_t usbd2_other_speed_config_descriptor_hs[] = { 0 };
 
 #else
@@ -950,7 +941,6 @@ __WEAK const uint8_t usbd2_other_speed_config_descriptor_hs[] = { 0 };
 #endif
 
 /* USB Device 2 Qualifier Descriptor (in Full Speed for High Speed) */
-extern const uint8_t usbd2_device_qualifier_fs[];
 __WEAK const uint8_t usbd2_device_qualifier_fs[] __ALIGNED(4) = {
   USB_DEVICE_QUALI_SIZE,                /* bLength */
   USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE, /* bDescriptorType */
@@ -964,7 +954,6 @@ __WEAK const uint8_t usbd2_device_qualifier_fs[] __ALIGNED(4) = {
 };
 
 /* USB Device 2 Qualifier Descriptor (in High Speed for Full Speed) */
-extern const uint8_t usbd2_device_qualifier_hs[];
 __WEAK const uint8_t usbd2_device_qualifier_hs[] __ALIGNED(4) = {
   USB_DEVICE_QUALI_SIZE,                /* bLength */
   USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE, /* bDescriptorType */
@@ -979,7 +968,6 @@ __WEAK const uint8_t usbd2_device_qualifier_hs[] __ALIGNED(4) = {
 
 /* USB Device 2 Configuration Descriptor (for High Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd2_config_descriptor_hs[];
 __WEAK const uint8_t usbd2_config_descriptor_hs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -1332,7 +1320,6 @@ __WEAK const uint8_t usbd2_config_descriptor_hs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD2_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -1721,7 +1708,6 @@ __WEAK const uint8_t usbd2_config_descriptor_hs[] __ALIGNED(4) = {
 
 /* USB Device 2 Other Speed Configuration Descriptor (in Full Speed for High Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd2_other_speed_config_descriptor_fs[];
 __WEAK const uint8_t usbd2_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -2002,7 +1988,6 @@ __WEAK const uint8_t usbd2_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD2_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -2367,7 +2352,6 @@ __WEAK const uint8_t usbd2_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
 
 /* USB Device 2 Other Speed Configuration Descriptor (in High Speed for Full Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd2_other_speed_config_descriptor_hs[];
 __WEAK const uint8_t usbd2_other_speed_config_descriptor_hs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -2648,7 +2632,6 @@ __WEAK const uint8_t usbd2_other_speed_config_descriptor_hs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD2_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -4227,10 +4210,7 @@ static const usbd2_ms_os_ext_compat_id_descriptor_t usbd2_ms_os_ext_compat_id_de
 #endif // ((USBD2_CUSTOM_CLASS_MS_COMPAT_CNT != 0) || (USBD2_CDC_MS_COMPAT_CNT != 0))
 #endif // (USBD2_OS_DESC_EN != 0)
 
-
 // Pointers to all descriptors
-extern 
-usbd_desc_t usbd2_desc;
 usbd_desc_t usbd2_desc = {
   usbd2_ep0_descriptor,
   usbd2_device_descriptor,

--- a/Components/USB/Source/usbd_config_desc_3.c
+++ b/Components/USB/Source/usbd_config_desc_3.c
@@ -1,17 +1,15 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    usbd_config_desc_3.c
  * Purpose: USB Device 3 Descriptor Creation
  *----------------------------------------------------------------------------*/
 
 /* USB Device 3 Endpoint 0 Descriptor */
-extern const uint8_t usbd3_ep0_descriptor[];
 __WEAK const uint8_t usbd3_ep0_descriptor[] __ALIGNED(4) = { USBD_EP0(3) };
 
 /* USB Device 3 Standard Descriptor */
-extern const uint8_t usbd3_device_descriptor[];
 __WEAK const uint8_t usbd3_device_descriptor[] __ALIGNED(4) = {
   USB_DEVICE_DESC_SIZE,                 /* bLength */
   USB_DEVICE_DESCRIPTOR_TYPE,           /* bDescriptorType */
@@ -42,7 +40,6 @@ __WEAK const uint8_t usbd3_device_descriptor[] __ALIGNED(4) = {
 
 /* USB Device 3 Configuration Descriptor (for Full Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd3_config_descriptor_fs[];
 __WEAK const uint8_t usbd3_config_descriptor_fs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -395,7 +392,6 @@ __WEAK const uint8_t usbd3_config_descriptor_fs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD3_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -932,15 +928,10 @@ __WEAK const uint8_t usbd3_config_descriptor_fs[] __ALIGNED(4) = {
 };
 
 #if (!USBD3_HS)                         /* If High-speed not enabled, declare dummy descriptors for High-speed */
-extern const uint8_t usbd3_device_qualifier_fs[];
 __WEAK const uint8_t usbd3_device_qualifier_fs[]              = { 0 };
-extern const uint8_t usbd3_device_qualifier_hs[];
 __WEAK const uint8_t usbd3_device_qualifier_hs[]              = { 0 };
-extern const uint8_t usbd3_config_descriptor_hs[];
 __WEAK const uint8_t usbd3_config_descriptor_hs[]             = { 0 };
-extern const uint8_t usbd3_other_speed_config_descriptor_fs[];
 __WEAK const uint8_t usbd3_other_speed_config_descriptor_fs[] = { 0 };
-extern const uint8_t usbd3_other_speed_config_descriptor_hs[];
 __WEAK const uint8_t usbd3_other_speed_config_descriptor_hs[] = { 0 };
 
 #else
@@ -950,7 +941,6 @@ __WEAK const uint8_t usbd3_other_speed_config_descriptor_hs[] = { 0 };
 #endif
 
 /* USB Device 3 Qualifier Descriptor (in Full Speed for High Speed) */
-extern const uint8_t usbd3_device_qualifier_fs[];
 __WEAK const uint8_t usbd3_device_qualifier_fs[] __ALIGNED(4) = {
   USB_DEVICE_QUALI_SIZE,                /* bLength */
   USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE, /* bDescriptorType */
@@ -964,7 +954,6 @@ __WEAK const uint8_t usbd3_device_qualifier_fs[] __ALIGNED(4) = {
 };
 
 /* USB Device 3 Qualifier Descriptor (in High Speed for Full Speed) */
-extern const uint8_t usbd3_device_qualifier_hs[];
 __WEAK const uint8_t usbd3_device_qualifier_hs[] __ALIGNED(4) = {
   USB_DEVICE_QUALI_SIZE,                /* bLength */
   USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE, /* bDescriptorType */
@@ -979,7 +968,6 @@ __WEAK const uint8_t usbd3_device_qualifier_hs[] __ALIGNED(4) = {
 
 /* USB Device 3 Configuration Descriptor (for High Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd3_config_descriptor_hs[];
 __WEAK const uint8_t usbd3_config_descriptor_hs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -1332,7 +1320,6 @@ __WEAK const uint8_t usbd3_config_descriptor_hs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD3_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -1721,7 +1708,6 @@ __WEAK const uint8_t usbd3_config_descriptor_hs[] __ALIGNED(4) = {
 
 /* USB Device 3 Other Speed Configuration Descriptor (in Full Speed for High Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd3_other_speed_config_descriptor_fs[];
 __WEAK const uint8_t usbd3_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -2002,7 +1988,6 @@ __WEAK const uint8_t usbd3_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD3_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -2367,7 +2352,6 @@ __WEAK const uint8_t usbd3_other_speed_config_descriptor_fs[] __ALIGNED(4) = {
 
 /* USB Device 3 Other Speed Configuration Descriptor (in High Speed for Full Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-extern const uint8_t usbd3_other_speed_config_descriptor_hs[];
 __WEAK const uint8_t usbd3_other_speed_config_descriptor_hs[] __ALIGNED(4) = {
   /* Configuration 1 */
   USB_CONFIGURATION_DESC_SIZE,          /* bLength */
@@ -2648,7 +2632,6 @@ __WEAK const uint8_t usbd3_other_speed_config_descriptor_hs[] __ALIGNED(4) = {
 #endif
 #endif
 #endif
-
 
 #if (USBD3_CUSTOM_CLASS3)
 #if (USBD_CUSTOM_CLASS3_IAD_EN)
@@ -4227,10 +4210,7 @@ static const usbd3_ms_os_ext_compat_id_descriptor_t usbd3_ms_os_ext_compat_id_de
 #endif // ((USBD3_CUSTOM_CLASS_MS_COMPAT_CNT != 0) || (USBD3_CDC_MS_COMPAT_CNT != 0))
 #endif // (USBD3_OS_DESC_EN != 0)
 
-
 // Pointers to all descriptors
-extern 
-usbd_desc_t usbd3_desc;
 usbd_desc_t usbd3_desc = {
   usbd3_ep0_descriptor,
   usbd3_device_descriptor,

--- a/Components/USB/Source/usbd_lib.h
+++ b/Components/USB/Source/usbd_lib.h
@@ -348,20 +348,4 @@ typedef struct {
   uint8_t              *inquiry_data[4];                    ///< pointer to data returned upon SCSI Inquiry request for 4 LUNs
 } const usbd_msc_t;
 
-/// Structure containing all descriptors (except report descriptor)
-typedef struct {
-  const uint8_t        *ep0_descriptor;                     ///< Control Endpoint 0 descriptor
-  const uint8_t        *device_descriptor;                  ///< device descriptor
-  const uint8_t        *device_qualifier_fs;                ///< device qualifier for low/full-speed
-  const uint8_t        *device_qualifier_hs;                ///< device qualifier for high-speed
-  const uint8_t        *config_descriptor_fs;               ///< configuration descriptor for low/full-speed
-  const uint8_t        *config_descriptor_hs;               ///< configuration descriptor for high-speed
-  const uint8_t        *other_speed_config_descriptor_fs;   ///< other speed configuration descriptor for low/full-speed
-  const uint8_t        *other_speed_config_descriptor_hs;   ///< other speed configuration descriptor for high-speed
-  const uint8_t        *string_descriptor;                  ///< string descriptors
-        uint8_t        *ser_num_string_descriptor;          ///< serial number string descriptor
-  const uint8_t        *ms_os_string_descriptor;            ///< Microsoft OS string descriptor
-  const uint8_t        *ms_os_ext_compat_id_descriptor;     ///< Microsoft Extended Compat ID OS Feature Descriptor 
-} usbd_desc_t;
-
 #endif  // USBD_LIB_H_

--- a/Documentation/Doxygen/USB/src/rl_usb.txt
+++ b/Documentation/Doxygen/USB/src/rl_usb.txt
@@ -4529,6 +4529,9 @@ The USB Device MSC Class configuration file <b>USBD_Config_MSC_n.h</b> contains 
 <b>Used in</b>
 - USB Device Function: \ref USBD_CustomClassn_Endpoint0_SetupPacketReceived; \ref USBD_CustomClassn_Endpoint0_SetupPacketProcessed;
 
+\struct usbd_desc_t
+\brief USB Device Descriptors structure
+
 \struct CDC_LINE_CODING
 \brief CDC Line Coding structure
 \details

--- a/Documentation/Doxygen/USB/src/usb_device.md
+++ b/Documentation/Doxygen/USB/src/usb_device.md
@@ -207,15 +207,16 @@ can be easily overridden by user code by creating descriptors with the same name
 |----------------------------------------------------------|------------------------------------------------------
 | `const uint8_t usbdn_ep0_descriptor[]`                   | Control Endpoint 0 descriptor
 | `const uint8_t usbdn_device_descriptor[]`                | USB Device descriptor
-| `const uint8_t usbdn_string_descriptor[]`                | String descriptors
-| `const uint8_t usbdn_device_qualifier_fs[]`              | Device qualifier for low/full-speed
-| `const uint8_t usbdn_device_qualifier_hs[]`              | Device qualifier for high-speed
 | `const uint8_t usbdn_config_descriptor_fs[]`             | Configuration descriptor for low/full-speed
 | `const uint8_t usbdn_config_descriptor_hs[]`             | Configuration descriptor for high-speed
+| `const uint8_t usbdn_device_qualifier_fs[]`              | Device qualifier for low/full-speed
+| `const uint8_t usbdn_device_qualifier_hs[]`              | Device qualifier for high-speed
 | `const uint8_t usbdn_other_speed_config_descriptor_fs[]` | Other speed configuration descriptor for low/full-speed
 | `const uint8_t usbdn_other_speed_config_descriptor_hs[]` | Other speed configuration descriptor for high-speed
 
 \note `n` in `usbdn_` represents the USB Device instance. So for the USB Device 0 instance, you have to use `usbd0_...`
+
+\note String descriptor cannot be replaced this way.
 
 **Code Example**
 
@@ -269,12 +270,10 @@ const uint8_t dev0_device_descriptor[] = {
   1U           // bNumConfigurations = 1 = 1 configuration
 };
 
-extern usbd_desc_t usbd0_desc;
- 
 int main (void) {
 
 ...
-usbd0_desc.device_descriptor = (uint8_t *)dev0_device_descriptor;
+  usbd0_desc.device_descriptor = dev0_device_descriptor;
 ...
  
 }

--- a/Documentation/Doxygen/USB/src/usb_structs.txt
+++ b/Documentation/Doxygen/USB/src/usb_structs.txt
@@ -73,18 +73,17 @@ typedef struct {
   uint8_t           bMaxPower;          ///< Maximum power consumption of the USB device from the bus in this specific configuration when the device is fully operational. Expressed in 2 mA units (i.e., 50 = 100 mA).
 } USB_CONFIGURATION_DESCRIPTOR;
 
-/*
-/// Structure containing all descriptors
-typedef struct _usbd_desc_t {
-  uint8_t          *ep0_descriptor;                     ///< Control \ref USB_Endpoint_Descriptor "Endpoint 0 descriptor"
-  uint8_t          *device_descriptor;                  ///< \ref USB_Device_Descriptor
-  uint8_t          *device_qualifier_fs;                ///< \ref USB_Device_Qualifier_Descriptor for low/full-speed
-  uint8_t          *device_qualifier_hs;                ///< \ref USB_Device_Qualifier_Descriptor for high-speed
-  uint8_t          *config_descriptor_fs;               ///< \ref USB_Configuration_Descriptor for low/full-speed
-  uint8_t          *config_descriptor_hs;               ///< \ref USB_Configuration_Descriptor for high-speed
-  uint8_t          *other_speed_config_descriptor_fs;   ///< Other speed \ref USB_Configuration_Descriptor for low/full-speed
-  uint8_t          *other_speed_config_descriptor_hs;   ///< Other speed \ref USB_Configuration_Descriptor for high-speed
-  uint8_t          *string_descriptor;                  ///< \ref USB_String_Descriptor
-  uint8_t          *ser_num_string_descriptor;          ///< \ref USB_String_Descriptor
+typedef struct {
+  const uint8_t    *ep0_descriptor;                     ///< Pointer to Control \ref USB_Endpoint_Descriptor "Endpoint 0 descriptor"
+  const uint8_t    *device_descriptor;                  ///< Pointer to \ref USB_Device_Descriptor
+  const uint8_t    *device_qualifier_fs;                ///< Pointer to \ref USB_Device_Qualifier_Descriptor for low/full-speed
+  const uint8_t    *device_qualifier_hs;                ///< Pointer to \ref USB_Device_Qualifier_Descriptor for high-speed
+  const uint8_t    *config_descriptor_fs;               ///< Pointer to \ref USB_Configuration_Descriptor for low/full-speed
+  const uint8_t    *config_descriptor_hs;               ///< Pointer to \ref USB_Configuration_Descriptor for high-speed
+  const uint8_t    *other_speed_config_descriptor_fs;   ///< Pointer to Other speed \ref USB_Configuration_Descriptor for low/full-speed
+  const uint8_t    *other_speed_config_descriptor_hs;   ///< Pointer to Other speed \ref USB_Configuration_Descriptor for high-speed
+  const uint8_t    *string_descriptor;                  ///< Pointer to \ref USB_String_Descriptor
+        uint8_t    *ser_num_string_descriptor;          ///< Pointer to Serial Number \ref USB_String_Descriptor
+  const uint8_t    *ms_os_string_descriptor;            ///< Pointer to Microsoft OS string descriptor
+  const uint8_t    *ms_os_ext_compat_id_descriptor;     ///< Pointer to Microsoft Extended Compat ID OS Feature Descriptor 
 } usbd_desc_t;
-*/


### PR DESCRIPTION
- since descriptors could be overridden externally, and that was documented, these structures and variables were moved back to main rl_usb.h (issue: https://github.com/ARM-software/MDK-Middleware/issues/42)