### PR TITLE
Update work_with_examples.md

### DIFF
--- a/Documentation/Doxygen/General/src/work_with_examples.md
+++ b/Documentation/Doxygen/General/src/work_with_examples.md
@@ -35,11 +35,11 @@ Once the *csolution project* is loaded the VS Code IDE presents you with a dialo
 > **Notes:**
 >
 > - The **Add Software Layer** dialog only appears when the BSP contains a board layer with compatible API Interfaces (see next section).
-> - ST board layers are configured for the Arm Compiler (AC6) using CubeMX.  However, it is easy to reconfigure for different compilers. The steps are provided in the BSP overview.
+> - ST board layers are configured for the Arm Compiler (AC6) using STM32CubeMX.  However, it is easy to reconfigure for different compilers. The steps are provided in the BSP overview.
 
 ### API Interfaces
 
-The MDK Middleware reference applications are hardware agnostic but require API Interfaces that are expressed using the *csolution project* [connections:](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/YML-Input-Format.md#connections) node. The various reference applications consume the following API Interfaces. These [interfaces should be provided by the board layer](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) that is part of the Board Support Pack (BSP).
+The MDK-Middleware Reference Applications are hardware agnostic but require API Interfaces that are expressed using the *csolution project* [connections:](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/YML-Input-Format.md#connections) node. The various reference applications consume the following API Interfaces. These [interfaces should be provided by the board layer](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) that is part of the Board Support Pack (BSP).
 
 Consumed API Interface      | Description
 :---------------------------|:----------------
@@ -105,7 +105,7 @@ To call uVision with the *csolution project* that you are using in VS Code, add 
 
 Use the VS Code menu command **Terminal - Run Task...** to Start uVision.  uVision can directly load *csolution projects*. After you have configured the debugger for your target system you may use the [Debug Windows and Dialogs](https://developer.arm.com/documentation/101407/0541/Debugging/Debug-Windows-and-Dialogs) to validate your application.
 
-Refer to [Application Note 320: Using Event Recorder for debugging a network performance issue](https://developer.arm.com/documentation/kan320/latest/) for an tutorial on how to analyze MDK Middleware issues.
+Refer to [Application Note 320: Using Event Recorder for debugging a network performance issue](https://developer.arm.com/documentation/kan320/latest/) for an tutorial on how to analyze MDK-Middleware issues.
 
 ## Using uVision IDE
 
@@ -115,33 +115,36 @@ The [uVision v5.41](https://www.keil.arm.com/mdk-community/) IDE or higher allow
 
 ### Create a native uVision Project
 
-As uVision IDE is easy-to-use and powerful many developers want to use this IDE for productive software development. Once configured with a compatible board layer, the Reference Applications can be recreated as clean, native uVision project using these steps.
+As uVision IDE is easy-to-use and powerful many developers want to use this IDE for productive software development. The MDK-Middleware Reference Applications can be recreated as clean, native uVision project by following the steps listed below, once configured with a compatible board layer. Such a board layer can be copied from an existing working csolution project in VS Code by following the section [Using VS Code](https://arm-software.github.io/MDK-Middleware/latest/General/working_with_examples.html#autotoc_md1) above, or from an exisitng BSP pack that contains a board layer.
 
-1. Create a new folder and copy the source files of the reference application and the software layer. It is recommended to keep the folder structure. In this new folder create a new uVision project and select the target device.
-2. Add source files and software components listed in the `cproject.yml` and `clayer.yml` using the uVision dialogs.
-3. Copy the existing configuration files to the RTE directory of the new uVision project.
-4. Configure tool settings using the uVision options dialogs and add linker script.
+1. Create a new folder and copy the source files of the MDK-Middleware Reference Application and the software layer, e.g. the board layer. It is recommended to keep the folder structure. In this new folder create a new uVision project for the selected target device.
+2. Add source files and software components listed in the `*.cproject.yml` of the MDK-Middleware Reference Application and `*.clayer.yml` 
+of the software layer e.g. the board layer into the new µVision project using the uVision dialogs.
+3. Copy the existing Run-Time-Environment (RTE) configuration files as well as the board layer files to the correct subdirectory of the new uVision project.
+4. Configure tool settings using the uVision *Options for Target* dialogs and add linker script.
 
-These steps are described in more detail below.
 
-Once the new project is created, it may be expanded with additional software components or modified to custom hardware as shown in the picture below. Note that uVision projects have no dependency on specify hardware boards.
 
-![Create new project in uVision](Create-uVision-Project.png)
+**These steps are described in more detail below.**
+
+MDK-Middleware Reference Applications contain a collection of projects. Taking the USB Device HID project from the MDK-Middleware Reference Applications as an example. Case 1 represents the case with an existing csolution project created in VS Code by following the section [Using VS Code](https://arm-software.github.io/MDK-Middleware/latest/General/working_with_examples.html#autotoc_md1) above. Case 2 represents the case without an existing csolution project when copying from the Examples subfolder of the MDK-Middleware pack v8.x as well as from a BSP pack containing the board layer.
 
 #### Create new Project Folder
 
-Reference Applications contain typically a collection of projects. In a bespoke uVision project, most likely only a subset is required. Choose the example that to want to start from, then create a new folder and copy the source files from the Reference Application. Below this is exemplified on USB Device HID.
+ Create a new folder for the µVision project and copy the source files from the MDK-Middleware Reference Application.
 
-*csolution project*        | copy to new uVision project folder      | Notes
-:--------------------------|:----------------------------------------|:-------------
-`./HID`                    | `<MyFolder>/HID`                        | Only copy content from root.
-`./Board/<board>`          | `<MyFolder>/Board/<board>`              | Only copy source files (`*.c` and `*.h`).
 
-From the uVision menu use *Project - New uVision Project...* dialog to select the device that you are using.
+
+Case 1: from csolution project | Case 2: from packs                | copy to new uVision project folder   | Notes
+:------------------------------|:----------------------------------|:-------------------------------------|:------
+`./HID`                        |`./Examples/USB/Device/HID` from MDK-Middleware pack| `<MyFolder>/HID`                     | Only copy content from the root directory without subfolders
+`./Board/<board_name>`         |`./Layers/Default/` from a BSP pack| `<MyFolder>/Board/<board_name>`      | Only copy source files (`*.c` and `*.h`) from the root directory without subfolders
+
+From the uVision menu use *Project - New uVision Project...* dialog to select the device that you are using and create a new µVision project.
 
 #### Add Source Files and Components
 
-The `cproject.yml` and `clayer.yml` contains a list of source files and components that should be added to the new uVision project.
+The `*.cproject.yml` of the reference application and `*.clayer.yml` of the software layer, e.g. board layer contain a list of source files and components that should be added to the new uVision project.
 
 - Add source files: In the uVision Project Window, click on a file group and *Add Existing Files to Group*. Feel free to add more file groups to structure your project.
   
@@ -149,40 +152,45 @@ The `cproject.yml` and `clayer.yml` contains a list of source files and componen
 
 > **Note:**
 >
-> - Do not start a generator such as CubeMX as the configuration is copied in the next step.
+> - Do not start a generator such as STM32CubeMX at this step as the configuration files are copied in the next step.
 
 #### Copy Config Files
 
-The RTE configuration files and generator files (for CubeMX or MCUXpresso Config) are fully compatible with uVision. However the folder structure is different.
+The RTE configuration files and generator files (for STM32CubeMX or MCUXpresso Config) are fully compatible with uVision. Follow the table below to copy these configuration files to the µVision project folder
 
-*csolution project*      | copy to new uVision project folder       | Notes
-:------------------------|:-----------------------------------------|:------------
-`./HID/RTE`              | `<MyFolder>/RTE`                         | Only copy component folders; exclude folders that start with `_` .
-`./Board/RTE`            | `<MyFolder>/RTE`                         | Only copy component folders; exclude folders that start with `_` .
-`./Board/<board>`        | `<MyFolder>/STM32CubeMX/<target>`        | Rename the `*.cgen.yml` file.
+Case 1: from csolution project   | Case 2: from packs  | copy to new uVision project folder       | Notes
+:--------------------------------|:--------------------|:-----------------------------------------|:------------
+`./HID/RTE`                      |`./Examples/USB/Device/HID/RTE` from MDK-Middleware pack| `<MyFolder>/RTE`                         | Only copy component folders excluding folders that start with `_` 
+`./Board/<board_name>/RTE`       |`./Layers/Default/RTE` from a BSP pack  | `<MyFolder>/RTE`                         | Only copy component folders excluding folders that start with `_` 
+`./Board/<board_name/CubeMX>`    |`./Layers/Default/CubeMX` from a BSP pack | `<MyFolder>/STM32CubeMX/<uVision_target_name>` | Rename the `*.cgen.yml` file
 
 > **Note:**
 >
-> - The `*.cgen.yml` file has a different name that is derived from your project name, i.e. `<MyProject>.cgen.yml`.
+> - The `*.cgen.yml` file copied from the existing csoution project or from the BSP pack must be renamed to match your µVision project name, i.e. `<MyProject>.cgen.yml`.
 
 #### Configure Tool Settings
 
-The settings of the *csolution project* are in the `*.yml` files. Adjust these settings in uVision using the tabs of the *Options* dialog:
+In the Case 1 the compiler toolchain relevant settings of the *csolution project* are in the `*.csolution.yml` and `*.cproject.yml` files. Based on these settings configure compiler toolchain in uVision using the tabs of the *Options* dialog:
 
 - *Target*: verify that hardware settings are correctly reflected, i.e. `Software Model: TrustZone Off`.
 
-- *C/C++ (AC6)*: Adjust Language / Code Generation as the default settings of the CMSIS-Toolbox differ.
+- *C/C++ (AC6)*: Adjust Language / Code Generation.
   - Typical settings: Optimization: `-O1` (for Debug), `-O3` (for Release), Warnings: `AC5-like`, Language C: `C11`.
-  - Defines that are in the *csolution project* should be reflected. Typically there is a define of `CMSIS_target_header` in the `Board.clayer.yml` that also requires an include path.
+  - Board layer specific definitions are defined in a header file, such as `board_name.h`, which can be found in `./Board/<board_name>` of the *csolution project* in the Case 1 or in the `./Layers/Default/` of the BSP pack in the Case 2. This `board_name.h` should be set as the value of a preprocessor symbol `CMSIS_target_header` in *Options for Target - C/C++(AC6) - Preprocessor Symbols*  
 
   ![Typical Compiler Options Settings](Options-C.png)
 
 - *Linker*: Configure Scatter File and adjust warnings.
-  - The native uVision project manager does not offer the same [linker script management](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/build-overview.md#linker-script-management) as a CMSIS Solution project in VS Code IDE. Therefore follow these steps to configure a scatter file.
-        1. Copy Linker Script Templates file e.g. `ac6_linker_script.sct.src` from the directory <cmsis-toolbox-installation-dir>/etc of the CMSIS-Toolbox or from the RTE directory of the BSP pack to `<MyFolder>/Board/<board>`.
-        2. Copy the memory regions header file e.g. regions_xxx.h from the RTE directory of the BSP pack to `<MyFolder>/Board/<board>`.
-        3. Add C preprocessor, such as `#! armclang --target=arm-arm-none-eabi -march=armv7-m -E -x c`, to the first line of `ac6_linker_script.sct.src`
-        4. Add `#include "regions_xxx.h"` to `ac6_linker_script.sct.src`
-  - In `cdefault.yml` included in some reference applications there may be some linker controls that should be reflected in this dialog, for example `--diag_suppress=L6314W`.
+  - In the Case 1 with an existing csolution project, a read-to-use linker scatter file that has already been preprocessed by CMSIS-Toolbox in VS Code, typically located in `.\tmp\1\ac6_linker_script.sct`, should be copied to `<MyFolder>/Board/<board_name>` . In the Case 2 without an existing csolution project, since the native uVision project manager does not offer the same [linker script management](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/build-overview.md#linker-script-management) as a csoution project in VS Code IDE. follow these steps to configure a scatter file in µVision.
+        1. Copy Linker Script Templates file e.g. `ac6_linker_script.sct.src` from the directory <cmsis-toolbox-installation-dir>/etc of the CMSIS-Toolbox or from the RTE directory of the BSP pack, such as `./Layers/Default/RTE`, to `<MyFolder>/Board/<board_name>`.
+        2. Copy the memory regions header file e.g. regions_xxx.h from the same RTE directory of the BSP pack to `<MyFolder>/Board/<board_name>`.
+        3. Add C preprocessor, such as `#! armclang --target=arm-arm-none-eabi -march=armv7-m -E -x c`, as the first line of `ac6_linker_script.sct.src`
+        4. Add `#include "regions_xxx.h"` as the second line to `ac6_linker_script.sct.src`
+  - In `cdefault.yml` included in some MDK-Middleware Reference Applications there may be some linker controls that should be reflected in this dialog, for example `--diag_suppress=L6314W`.
 
   ![Typical Linker Options Settings](Options-Linker.png)
+
+#### Expand with additional components
+Once the new project is created, it may be expanded with additional software components or modified to custom hardware as shown in the picture below. Note that uVision projects have no dependency on specify hardware boards.
+
+![Create new project in uVision](Create-uVision-Project.png)


### PR DESCRIPTION
A big rewrite on the section "Working with Examples - Using µVision IDE" to cover both user cases, i.e. with and without an existing VS Code project