### PR TITLE
Examples: update cdefault.yml

### DIFF
--- a/.ci/cdefault.yml
+++ b/.ci/cdefault.yml
@@ -1,4 +1,5 @@
 default:
+
   misc:
     - for-compiler: AC6
       C-CPP:
@@ -31,7 +32,9 @@ default:
       Link:
         - --specs=nano.specs
         - -Wl,-Map=$elf()$.map
+        - -Wl,-print-memory-usage
         - -Wl,--gc-sections
+        - -Wl,--no-warn-rwx-segments   # suppress incorrect linker warning
 
     - for-compiler: CLANG
       ASM:
@@ -46,6 +49,7 @@ default:
       Link:
         - -lcrt0
         - -Wl,-Map=$elf()$.map
+        - -Wl,-print-memory-usage
         - -Wl,--gc-sections
 
     - for-compiler: IAR

--- a/Examples/FileSystem/cdefault.yml
+++ b/Examples/FileSystem/cdefault.yml
@@ -1,4 +1,5 @@
 default:
+
   misc:
     - for-compiler: AC6
       C-CPP:
@@ -31,7 +32,9 @@ default:
       Link:
         - --specs=nano.specs
         - -Wl,-Map=$elf()$.map
+        - -Wl,-print-memory-usage
         - -Wl,--gc-sections
+        - -Wl,--no-warn-rwx-segments   # suppress incorrect linker warning
 
     - for-compiler: CLANG
       ASM:
@@ -46,6 +49,7 @@ default:
       Link:
         - -lcrt0
         - -Wl,-Map=$elf()$.map
+        - -Wl,-print-memory-usage
         - -Wl,--gc-sections
 
     - for-compiler: IAR

--- a/Examples/Network/cdefault.yml
+++ b/Examples/Network/cdefault.yml
@@ -1,4 +1,5 @@
 default:
+
   misc:
     - for-compiler: AC6
       C-CPP:
@@ -31,7 +32,9 @@ default:
       Link:
         - --specs=nano.specs
         - -Wl,-Map=$elf()$.map
+        - -Wl,-print-memory-usage
         - -Wl,--gc-sections
+        - -Wl,--no-warn-rwx-segments   # suppress incorrect linker warning
 
     - for-compiler: CLANG
       ASM:
@@ -46,6 +49,7 @@ default:
       Link:
         - -lcrt0
         - -Wl,-Map=$elf()$.map
+        - -Wl,-print-memory-usage
         - -Wl,--gc-sections
 
     - for-compiler: IAR

--- a/Examples/USB/Device/cdefault.yml
+++ b/Examples/USB/Device/cdefault.yml
@@ -1,4 +1,5 @@
 default:
+
   misc:
     - for-compiler: AC6
       C-CPP:
@@ -31,7 +32,9 @@ default:
       Link:
         - --specs=nano.specs
         - -Wl,-Map=$elf()$.map
+        - -Wl,-print-memory-usage
         - -Wl,--gc-sections
+        - -Wl,--no-warn-rwx-segments   # suppress incorrect linker warning
 
     - for-compiler: CLANG
       ASM:
@@ -46,6 +49,7 @@ default:
       Link:
         - -lcrt0
         - -Wl,-Map=$elf()$.map
+        - -Wl,-print-memory-usage
         - -Wl,--gc-sections
 
     - for-compiler: IAR

--- a/Examples/USB/Host/cdefault.yml
+++ b/Examples/USB/Host/cdefault.yml
@@ -1,4 +1,5 @@
 default:
+
   misc:
     - for-compiler: AC6
       C-CPP:
@@ -31,7 +32,9 @@ default:
       Link:
         - --specs=nano.specs
         - -Wl,-Map=$elf()$.map
+        - -Wl,-print-memory-usage
         - -Wl,--gc-sections
+        - -Wl,--no-warn-rwx-segments   # suppress incorrect linker warning
 
     - for-compiler: CLANG
       ASM:
@@ -46,6 +49,7 @@ default:
       Link:
         - -lcrt0
         - -Wl,-Map=$elf()$.map
+        - -Wl,-print-memory-usage
         - -Wl,--gc-sections
 
     - for-compiler: IAR

--- a/Test/Network/netio/cdefault.yml
+++ b/Test/Network/netio/cdefault.yml
@@ -1,4 +1,5 @@
 default:
+
   misc:
     - for-compiler: AC6
       C-CPP:
@@ -31,7 +32,9 @@ default:
       Link:
         - --specs=nano.specs
         - -Wl,-Map=$elf()$.map
+        - -Wl,-print-memory-usage
         - -Wl,--gc-sections
+        - -Wl,--no-warn-rwx-segments   # suppress incorrect linker warning
 
     - for-compiler: CLANG
       ASM:
@@ -46,6 +49,7 @@ default:
       Link:
         - -lcrt0
         - -Wl,-Map=$elf()$.map
+        - -Wl,-print-memory-usage
         - -Wl,--gc-sections
 
     - for-compiler: IAR


### PR DESCRIPTION
- add program size information to GCC and CLANG build output
- suppress incorrect linker warning for GCC