### PR TITLE
GitHub Actions: Run build_fs on an ARM processor

### DIFF
--- a/.github/workflows/build_fs.yml
+++ b/.github/workflows/build_fs.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         compiler: [AC6, GCC]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout MDK-Middleware


### PR DESCRIPTION
[Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) --> `ubuntu-24.04-arm`
* https://github.com/ARM-software/MDK-Middleware/tree/main/.github/workflows