### PR TITLE
Examples: update USB examples

### DIFF
--- a/Examples/USB/Device/HID/HID.c
+++ b/Examples/USB/Device/HID/HID.c
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2025 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    HID.c
  * Purpose: USB Device - Human Interface Device example
@@ -14,14 +14,6 @@
 #include "cmsis_vio.h"
 
 #include "rl_usb.h"
-
-// Main stack size must be multiple of 8 Bytes
-#define APP_MAIN_STK_SZ (4096U)
-static uint64_t app_main_stk[APP_MAIN_STK_SZ / 8];
-static const osThreadAttr_t app_main_attr = {
-  .stack_mem  = &app_main_stk[0],
-  .stack_size = sizeof(app_main_stk)
-};
 
 /*-----------------------------------------------------------------------------
  * Application main thread
@@ -52,7 +44,7 @@ __NO_RETURN void app_main_thread (void *argument) {
  *----------------------------------------------------------------------------*/
 int app_main (void) {
   osKernelInitialize();
-  osThreadNew(app_main_thread, NULL, &app_main_attr);
+  osThreadNew(app_main_thread, NULL, NULL);
   osKernelStart();
   return 0;
 }

--- a/Examples/USB/Device/HID/RTE/CMSIS/RTX_Config.h
+++ b/Examples/USB/Device/HID/RTE/CMSIS/RTX_Config.h
@@ -44,7 +44,7 @@
 //   <i> Defines the combined global dynamic memory size.
 //   <i> Default: 32768
 #ifndef OS_DYNAMIC_MEM_SIZE
-#define OS_DYNAMIC_MEM_SIZE         32768
+#define OS_DYNAMIC_MEM_SIZE         4096
 #endif
  
 //   <o>Kernel Tick Frequency [Hz] <1-1000000>
@@ -179,7 +179,7 @@
 //   <i> Defines stack size for threads with zero stack size specified.
 //   <i> Default: 3072
 #ifndef OS_STACK_SIZE
-#define OS_STACK_SIZE               3072
+#define OS_STACK_SIZE               1024
 #endif
  
 //   <o>Idle Thread Stack size [bytes] <72-1073741824:8>

--- a/Examples/USB/Device/MassStorage/MassStorage.c
+++ b/Examples/USB/Device/MassStorage/MassStorage.c
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2025 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    MassStorage.c
  * Purpose: USB Device - Mass Storage example
@@ -13,14 +13,6 @@
 #include "cmsis_os2.h"
 
 #include "rl_usb.h"
-
-// Main stack size must be multiple of 8 Bytes
-#define APP_MAIN_STK_SZ (4096U)
-static uint64_t app_main_stk[APP_MAIN_STK_SZ / 8];
-static const osThreadAttr_t app_main_attr = {
-  .stack_mem  = &app_main_stk[0],
-  .stack_size = sizeof(app_main_stk)
-};
 
 /*-----------------------------------------------------------------------------
  * Application main thread
@@ -41,7 +33,7 @@ void app_main_thread (void *argument) {
  *----------------------------------------------------------------------------*/
 int app_main (void) {
   osKernelInitialize();
-  osThreadNew(app_main_thread, NULL, &app_main_attr);
+  osThreadNew(app_main_thread, NULL, NULL);
   osKernelStart();
   return 0;
 }

--- a/Examples/USB/Device/MassStorage/RTE/CMSIS/RTX_Config.h
+++ b/Examples/USB/Device/MassStorage/RTE/CMSIS/RTX_Config.h
@@ -44,7 +44,7 @@
 //   <i> Defines the combined global dynamic memory size.
 //   <i> Default: 32768
 #ifndef OS_DYNAMIC_MEM_SIZE
-#define OS_DYNAMIC_MEM_SIZE         32768
+#define OS_DYNAMIC_MEM_SIZE         4096
 #endif
  
 //   <o>Kernel Tick Frequency [Hz] <1-1000000>
@@ -179,7 +179,7 @@
 //   <i> Defines stack size for threads with zero stack size specified.
 //   <i> Default: 3072
 #ifndef OS_STACK_SIZE
-#define OS_STACK_SIZE               3072
+#define OS_STACK_SIZE               1024
 #endif
  
 //   <o>Idle Thread Stack size [bytes] <72-1073741824:8>

--- a/Examples/USB/Device/VirtualCOM/RTE/CMSIS/RTX_Config.h
+++ b/Examples/USB/Device/VirtualCOM/RTE/CMSIS/RTX_Config.h
@@ -44,7 +44,7 @@
 //   <i> Defines the combined global dynamic memory size.
 //   <i> Default: 32768
 #ifndef OS_DYNAMIC_MEM_SIZE
-#define OS_DYNAMIC_MEM_SIZE         32768
+#define OS_DYNAMIC_MEM_SIZE         4096
 #endif
  
 //   <o>Kernel Tick Frequency [Hz] <1-1000000>
@@ -179,7 +179,7 @@
 //   <i> Defines stack size for threads with zero stack size specified.
 //   <i> Default: 3072
 #ifndef OS_STACK_SIZE
-#define OS_STACK_SIZE               3072
+#define OS_STACK_SIZE               1024
 #endif
  
 //   <o>Idle Thread Stack size [bytes] <72-1073741824:8>

--- a/Examples/USB/Device/VirtualCOM/VirtualCOM.c
+++ b/Examples/USB/Device/VirtualCOM/VirtualCOM.c
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2023 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2025 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    VirtualCOM.c
  * Purpose: USB Device - Virtual COM Port example
@@ -13,14 +13,6 @@
 #include "cmsis_os2.h"
 
 #include "rl_usb.h"
-
-// Main stack size must be multiple of 8 Bytes
-#define APP_MAIN_STK_SZ (4096U)
-static uint64_t app_main_stk[APP_MAIN_STK_SZ / 8];
-static const osThreadAttr_t app_main_attr = {
-  .stack_mem  = &app_main_stk[0],
-  .stack_size = sizeof(app_main_stk)
-};
 
 /*-----------------------------------------------------------------------------
  * Application main thread
@@ -41,7 +33,7 @@ void app_main_thread (void *argument) {
  *----------------------------------------------------------------------------*/
 int app_main (void) {
   osKernelInitialize();
-  osThreadNew(app_main_thread, NULL, &app_main_attr);
+  osThreadNew(app_main_thread, NULL, NULL);
   osKernelStart();
   return 0;
 }

--- a/Examples/USB/Host/Keyboard/Keyboard.c
+++ b/Examples/USB/Host/Keyboard/Keyboard.c
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Host
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2025 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    Keyboard.c
  * Purpose: USB Host - HID Keyboard example
@@ -11,14 +11,6 @@
 #include "main.h"
 
 #include "rl_usb.h"
-
-// Main stack size must be multiple of 8 Bytes
-#define APP_MAIN_STK_SZ (4096U)
-static uint64_t app_main_stk[APP_MAIN_STK_SZ / 8];
-static const osThreadAttr_t app_main_attr = {
-  .stack_mem  = &app_main_stk[0],
-  .stack_size = sizeof(app_main_stk)
-};
 
 /*-----------------------------------------------------------------------------
  * Application main thread
@@ -84,7 +76,7 @@ __NO_RETURN void app_main_thread (void *argument) {
  *----------------------------------------------------------------------------*/
 int app_main (void) {
   osKernelInitialize();
-  osThreadNew(app_main_thread, NULL, &app_main_attr);
+  osThreadNew(app_main_thread, NULL, NULL);
   osKernelStart();
   return 0;
 }

--- a/Examples/USB/Host/Keyboard/RTE/CMSIS/RTX_Config.h
+++ b/Examples/USB/Host/Keyboard/RTE/CMSIS/RTX_Config.h
@@ -44,7 +44,7 @@
 //   <i> Defines the combined global dynamic memory size.
 //   <i> Default: 32768
 #ifndef OS_DYNAMIC_MEM_SIZE
-#define OS_DYNAMIC_MEM_SIZE         32768
+#define OS_DYNAMIC_MEM_SIZE         4096
 #endif
  
 //   <o>Kernel Tick Frequency [Hz] <1-1000000>
@@ -179,7 +179,7 @@
 //   <i> Defines stack size for threads with zero stack size specified.
 //   <i> Default: 3072
 #ifndef OS_STACK_SIZE
-#define OS_STACK_SIZE               3072
+#define OS_STACK_SIZE               1024
 #endif
  
 //   <o>Idle Thread Stack size [bytes] <72-1073741824:8>

--- a/Examples/USB/Host/MassStorage/MassStorage.c
+++ b/Examples/USB/Host/MassStorage/MassStorage.c
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Host
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2025 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    MassStorage.c
  * Purpose: USB Host - Mass Storage example
@@ -14,14 +14,6 @@
 #include "rl_usb.h"
 
 #include "USBH_MSC.h"
-
-// Main stack size must be multiple of 8 Bytes
-#define APP_MAIN_STK_SZ (4096U)
-static uint64_t app_main_stk[APP_MAIN_STK_SZ / 8];
-static const osThreadAttr_t app_main_attr = {
-  .stack_mem  = &app_main_stk[0],
-  .stack_size = sizeof(app_main_stk)
-};
 
 /*-----------------------------------------------------------------------------
  * Application main thread
@@ -37,7 +29,6 @@ __NO_RETURN void app_main_thread (void *argument) {
   printf("USB Host Mass Storage example\n");
 
   usb_status = USBH_Initialize (0U);    // Initialize USB Host 0
-
   if (usb_status != usbOK) {
     for (;;) {}                         // Handle USB Host 0 init failure
   }
@@ -76,7 +67,7 @@ __NO_RETURN void app_main_thread (void *argument) {
  *----------------------------------------------------------------------------*/
 int app_main (void) {
   osKernelInitialize();
-  osThreadNew(app_main_thread, NULL, &app_main_attr);
+  osThreadNew(app_main_thread, NULL, NULL);
   osKernelStart();
   return 0;
 }

--- a/Examples/USB/Host/MassStorage/RTE/CMSIS/RTX_Config.h
+++ b/Examples/USB/Host/MassStorage/RTE/CMSIS/RTX_Config.h
@@ -44,7 +44,7 @@
 //   <i> Defines the combined global dynamic memory size.
 //   <i> Default: 32768
 #ifndef OS_DYNAMIC_MEM_SIZE
-#define OS_DYNAMIC_MEM_SIZE         32768
+#define OS_DYNAMIC_MEM_SIZE         4096
 #endif
  
 //   <o>Kernel Tick Frequency [Hz] <1-1000000>
@@ -179,7 +179,7 @@
 //   <i> Defines stack size for threads with zero stack size specified.
 //   <i> Default: 3072
 #ifndef OS_STACK_SIZE
-#define OS_STACK_SIZE               3072
+#define OS_STACK_SIZE               1024
 #endif
  
 //   <o>Idle Thread Stack size [bytes] <72-1073741824:8>


### PR DESCRIPTION
- reduce RAM allocated to RTOS (global memory pool)
- remove usage of statically allocated memory for main thread stack