### PR TITLE
Replaced references

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -1,6 +1,6 @@
 # MDK-Middleware Build Test
 
-This directory contains CMSIS Solution projects for build tests that generate libraries and examples (for a dummy device) using various compilers and the [CMSIS-Toolbox](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/README.md) as build system.
+This directory contains CMSIS Solution projects for build tests that generate libraries and examples (for a dummy device) using various compilers and the [CMSIS-Toolbox](https://open-cmsis-pack.github.io/cmsis-toolbox/) as build system.
 
 ## CI Test with GitHub Actions
 

--- a/Documentation/Doxygen/FileSystem/src/example_file_demo.md
+++ b/Documentation/Doxygen/FileSystem/src/example_file_demo.md
@@ -37,7 +37,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  
  - `CMSIS_MCI`: CMSIS-Driver for Memory Card Interface
  - `CMSIS_VIO`: CMSIS-Driver for Virtual I/O interface

--- a/Documentation/Doxygen/General/src/work_with_examples.md
+++ b/Documentation/Doxygen/General/src/work_with_examples.md
@@ -1,9 +1,9 @@
 # Working with Examples {#working_with_examples}
 
-The MDK-Middleware examples are implemented as [CMSIS-Toolbox Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md)
-that use [CMSIS-Driver](https://arm-software.github.io/CMSIS_6/latest/Driver/index.html) interfaces. These Reference Applications are hardware agnostic and need to be extended with a compatible [board layer](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#board-layer) to run on a specific hardware target.
+The MDK-Middleware examples are implemented as [CMSIS-Toolbox Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/)
+that use [CMSIS-Driver](https://arm-software.github.io/CMSIS_6/latest/Driver/index.html) interfaces. These Reference Applications are hardware agnostic and need to be extended with a compatible [board layer](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#board-layer) to run on a specific hardware target.
 
-Several [Board Support Packs (BSP)](https://www.keil.arm.com/packs/) contain board layers that support the MDK-Middleware components. Refer to the *Overview* page of the pack to check the *Provided connection API Interface* of the layers. When such a board layer is not available, it is possible to [create a compatible board layer](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#structure).
+Several [Board Support Packs (BSP)](https://www.keil.arm.com/packs/) contain board layers that support the MDK-Middleware components. Refer to the *Overview* page of the pack to check the *Provided connection API Interface* of the layers. When such a board layer is not available, it is possible to [create a compatible board layer](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#structure).
 
 ## Available examples
 
@@ -39,7 +39,7 @@ Once the *csolution project* is loaded the VS Code IDE presents you with a dialo
 
 ### API Interfaces
 
-The MDK-Middleware Reference Applications are hardware agnostic but require API Interfaces that are expressed using the *csolution project* [connections:](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/YML-Input-Format.md#connections) node. The various reference applications consume the following API Interfaces. These [interfaces should be provided by the board layer](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) that is part of the Board Support Pack (BSP).
+The MDK-Middleware Reference Applications are hardware agnostic but require API Interfaces that are expressed using the *csolution project* [connections:](https://open-cmsis-pack.github.io/cmsis-toolbox/YML-Input-Format#connections) node. The various reference applications consume the following API Interfaces. These [interfaces should be provided by the board layer](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) that is part of the Board Support Pack (BSP).
 
 Consumed API Interface      | Description
 :---------------------------|:----------------
@@ -196,7 +196,7 @@ In the Case 1 the compiler toolchain relevant settings of the *csolution project
   ![Typical Compiler Options Settings](Options-C.png)
 
 - *Linker*: Configure Scatter File and adjust warnings.
-  - In the Case 1 with an existing csolution project, a read-to-use linker scatter file that has already been preprocessed by CMSIS-Toolbox in VS Code, typically located in `.\tmp\1\ac6_linker_script.sct`, should be copied to `<MyFolder>/Board/<board_name>` . In the Case 2 without an existing csolution project, since the native uVision project manager does not offer the same [linker script management](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/build-overview.md#linker-script-management) as a csoution project in VS Code IDE. follow these steps to configure a scatter file in µVision.
+  - In the Case 1 with an existing csolution project, a read-to-use linker scatter file that has already been preprocessed by CMSIS-Toolbox in VS Code, typically located in `.\tmp\1\ac6_linker_script.sct`, should be copied to `<MyFolder>/Board/<board_name>` . In the Case 2 without an existing csolution project, since the native uVision project manager does not offer the same [linker script management](https://open-cmsis-pack.github.io/cmsis-toolbox/build-overview#linker-script-management) as a csoution project in VS Code IDE. follow these steps to configure a scatter file in µVision.
         1. Copy Linker Script Templates file e.g. `ac6_linker_script.sct.src` from the directory <cmsis-toolbox-installation-dir>/etc of the CMSIS-Toolbox or from the RTE directory of the BSP pack, such as `./Layers/Default/RTE`, to `<MyFolder>/Board/<board_name>`.
         2. Copy the memory regions header file e.g. regions_xxx.h from the same RTE directory of the BSP pack to `<MyFolder>/Board/<board_name>`.
         3. Add C preprocessor, such as `#! armclang --target=arm-arm-none-eabi -march=armv7-m -E -x c`, as the first line of `ac6_linker_script.sct.src`

--- a/Documentation/Doxygen/Network/src/example_bsd_client.md
+++ b/Documentation/Doxygen/Network/src/example_bsd_client.md
@@ -40,7 +40,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_ETH`: CMSIS-Driver for Ethernet interface
  - `CMSIS_VIO`: CMSIS-Driver for Virtual I/O interface
  - `STDOUT`: Standard Output redirection

--- a/Documentation/Doxygen/Network/src/example_bsd_server.md
+++ b/Documentation/Doxygen/Network/src/example_bsd_server.md
@@ -38,7 +38,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_ETH`: CMSIS-Driver for Ethernet interface
  - `CMSIS_VIO`: CMSIS-Driver for Virtual I/O interface
  - `STDOUT`: Standard Output redirection

--- a/Documentation/Doxygen/Network/src/example_ftp_server.md
+++ b/Documentation/Doxygen/Network/src/example_ftp_server.md
@@ -44,7 +44,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following CMSIS-Driver interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following CMSIS-Driver interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_ETH`: CMSIS-Driver for Ethernet interface
  - `CMSIS_MCI`: CMSIS-Driver for Memory Card Interface
  - `CMSIS_VIO`: CMSIS-Driver for Virtual I/O interface

--- a/Documentation/Doxygen/Network/src/example_http_server.md
+++ b/Documentation/Doxygen/Network/src/example_http_server.md
@@ -47,7 +47,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_ETH`: CMSIS-Driver for Ethernet interface
  - `CMSIS_VIO`: CMSIS-Driver for Virtual I/O interface
  - `STDOUT`: standard output stream redirection

--- a/Documentation/Doxygen/Network/src/example_http_upload.md
+++ b/Documentation/Doxygen/Network/src/example_http_upload.md
@@ -43,7 +43,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_ETH`: CMSIS-Driver for Ethernet interface
  - `CMSIS_MCI`: CMSIS-Driver for Memory Card Interface
  - `CMSIS_VIO`: CMSIS-Driver for Virtual I/O interface

--- a/Documentation/Doxygen/Network/src/example_https_server.md
+++ b/Documentation/Doxygen/Network/src/example_https_server.md
@@ -52,7 +52,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_ETH`: CMSIS-Driver for Ethernet interface
  - `CMSIS_VIO`: CMSIS-Driver for Virtual I/O interface
  - `STDOUT`: Standard Output redirection

--- a/Documentation/Doxygen/Network/src/example_smtp_client.md
+++ b/Documentation/Doxygen/Network/src/example_smtp_client.md
@@ -45,7 +45,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_ETH`: CMSIS-Driver for Ethernet interface
  - `CMSIS_VIO`: CMSIS-Driver for Virtual I/O interface
  - `STDOUT`: Standard Output redirection

--- a/Documentation/Doxygen/Network/src/example_smtps_client.md
+++ b/Documentation/Doxygen/Network/src/example_smtps_client.md
@@ -48,7 +48,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_ETH`: CMSIS-Driver for Ethernet interface
  - `CMSIS_VIO`: CMSIS-Driver for Virtual I/O interface
  - `STDOUT`: Standard Output redirection

--- a/Documentation/Doxygen/Network/src/example_snmp_agent.md
+++ b/Documentation/Doxygen/Network/src/example_snmp_agent.md
@@ -38,7 +38,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_ETH`: CMSIS-Driver for Ethernet interface
  - `CMSIS_VIO`: CMSIS-Driver for Virtual I/O interface
  - `STDOUT`: Standard Output redirection

--- a/Documentation/Doxygen/Network/src/example_telnet_server.md
+++ b/Documentation/Doxygen/Network/src/example_telnet_server.md
@@ -42,7 +42,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_ETH`: CMSIS-Driver for Ethernet interface
  - `CMSIS_VIO`: CMSIS-Driver for Virtual I/O interface
  - `STDIN`: Standard Input redirection

--- a/Documentation/Doxygen/Network/src/examples.md
+++ b/Documentation/Doxygen/Network/src/examples.md
@@ -13,4 +13,4 @@ MDK-Middleware provides a Network Reference Example that contains following proj
 - \subpage BSD_Client_Example shows how to use BSD sockets for network communication from a client side.
 - \subpage BSD_Server_Example shows how to use BSD sockets for network communication from a server side.
 
-See [CMSIS-Toolbox - Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md) to learn more about the reference application concept.
+See [CMSIS-Toolbox - Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/) to learn more about the reference application concept.

--- a/Documentation/Doxygen/USB/src/usbd_create_app.md
+++ b/Documentation/Doxygen/USB/src/usbd_create_app.md
@@ -73,8 +73,8 @@ The configuration file **USBD_Config_n.h** contains a number of important settin
   for more information on how to apply for a valid Vendor ID.
 - Every device variant needs an unique **Product ID**. Together with the **Vendor ID**, it is used by the Host computer's operating system
   to find a driver for your device.
-- The **Device Release Number** will be shown in Windows and Linux systems as “Firmware Revision”. The number will
-  be interpreted as “binary coded decimal”, meaning that 0x0101 will be shown as firmware revision 1.01.
+- The **Device Release Number** will be shown in Windows and Linux systems as "Firmware Revision". The number will
+  be interpreted as "binary coded decimal", meaning that 0x0101 will be shown as firmware revision 1.01.
 - The **Manufacturer**, **Product** and the **Serial Number String** can be set to identify the USB Device from the USB Host.
 
 Refer to \ref usbd_coreFunctions_conf "USB Core Configuration" for more configuration options of the USB Device.

--- a/Documentation/Doxygen/USB/src/usbd_example_cdc.md
+++ b/Documentation/Doxygen/USB/src/usbd_example_cdc.md
@@ -36,7 +36,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_USB_Device`: CMSIS-Driver for USB Device interface.
  - `CMSIS_VIO`: CMSIS-Driver for Virtual I/O interface.
  - `CMSIS_USART`: CMSIS-Driver for USART interface.

--- a/Documentation/Doxygen/USB/src/usbd_example_hid.md
+++ b/Documentation/Doxygen/USB/src/usbd_example_hid.md
@@ -36,7 +36,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_USB_Device`: CMSIS-Driver for USB Device interface.
  - `CMSIS_VIO`: CMSIS-Driver for Virtual I/O interface.
 

--- a/Documentation/Doxygen/USB/src/usbd_example_msc.md
+++ b/Documentation/Doxygen/USB/src/usbd_example_msc.md
@@ -37,7 +37,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_USB_Device`: CMSIS-Driver for USB Device interface.
  - `CMSIS_VIO`: CMSIS-Driver for Virtual I/O interface.
 

--- a/Documentation/Doxygen/USB/src/usbd_examples.md
+++ b/Documentation/Doxygen/USB/src/usbd_examples.md
@@ -6,4 +6,4 @@ MDK-Middleware provides a USB Device Reference Example that contains following p
  - \subpage usbd_example_msc example implements a mass storage USB device using internal RAM as storage media.
  - \subpage usbd_example_cdc example provides a virtual communication port to UART bridge to the USB Host.
 
-See [CMSIS-Toolbox - Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md) to learn more about the reference application concept in Open CMSIS Pack used by these examples.
+See [CMSIS-Toolbox - Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/) to learn more about the reference application concept in Open CMSIS Pack used by these examples.

--- a/Documentation/Doxygen/USB/src/usbh_example_hid.md
+++ b/Documentation/Doxygen/USB/src/usbh_example_hid.md
@@ -35,7 +35,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_USB_Host`: CMSIS-Driver for USB Host interface.
 
 ## Build the Project

--- a/Documentation/Doxygen/USB/src/usbh_example_msc.md
+++ b/Documentation/Doxygen/USB/src/usbh_example_msc.md
@@ -38,7 +38,7 @@ When a board layer is added to the project, corresponding configuration files fo
 
 <h2>Board Layer</h2>
 
-In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+In order to build the project it shall be extended with a compatible board layer that provides following interfaces as [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
  - `CMSIS_USB_Host`: CMSIS-Driver for USB Host interface.
 
 ## Build the Project

--- a/Documentation/Doxygen/USB/src/usbh_examples.md
+++ b/Documentation/Doxygen/USB/src/usbh_examples.md
@@ -5,4 +5,4 @@ MDK-Middleware provides a USB Host Reference Example that contains following pro
 - \subpage usbh_example_hid example shows how to interact with a USB keyboard from a microcontroller.
 - \subpage usbh_example_msc example shows how to access a USB memory stick from a microcontroller.
 
-See [CMSIS-Toolbox - Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.
+See [CMSIS-Toolbox - Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.

--- a/Examples/FileSystem/File_Demo/README.md
+++ b/Examples/FileSystem/File_Demo/README.md
@@ -6,6 +6,6 @@ For detailed description see [File Demo Example section in MDK-Middleware docume
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 You can mount and format drives and manage files and directories using commands such as `write`, `read`, `rename`, `delete`, `mkdir` and `rmdir`.

--- a/Examples/FileSystem/README.md
+++ b/Examples/FileSystem/README.md
@@ -8,4 +8,4 @@
 
 For more details refer to [File System Examples section in the MDK-Middleware documentation](https://arm-software.github.io/MDK-Middleware/latest/FileSystem/examples.html).
 
-Also see [CMSIS-Toolbox - Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.
+Also see [CMSIS-Toolbox - Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.

--- a/Examples/Network/BSD_Client/README.md
+++ b/Examples/Network/BSD_Client/README.md
@@ -6,7 +6,7 @@ For detailed description see [BSD Client Example section in MDK-Middleware docum
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 To run this example, you must use the automatically assigned IPv6 address or set the IPv4 address to match your local network.
 

--- a/Examples/Network/BSD_Server/README.md
+++ b/Examples/Network/BSD_Server/README.md
@@ -6,7 +6,7 @@ For detailed description see [BSD Server Example section in MDK-Middleware docum
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 To run this example, you must use the automatically assigned IPv6 address or set the IPv4 address to match your local network, otherwise the server cannot be reached. This is because the requests for non-LAN hosts are forwarded to the default gateway.
 

--- a/Examples/Network/FTP_Server/README.md
+++ b/Examples/Network/FTP_Server/README.md
@@ -6,7 +6,7 @@ For detailed description see [FTP Server Example section in MDK-Middleware docum
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 Connect an evaluation board to a LAN with a router. You can also connect an evaluation board directly to a PC using a direct or crossover network cable.
 

--- a/Examples/Network/HTTPS_Server/README.md
+++ b/Examples/Network/HTTPS_Server/README.md
@@ -6,7 +6,7 @@ For detailed description see [HTTPS Server Example section in MDK-Middleware doc
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 To use this example, connect an evaluation board to a LAN with a router. You can also connect an evaluation board directly to a PC using a direct or crossover network cable.
 

--- a/Examples/Network/HTTP_Server/README.md
+++ b/Examples/Network/HTTP_Server/README.md
@@ -6,7 +6,7 @@ For detailed description see [HTTP Server Example section in MDK-Middleware docu
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 To use this example, connect an evaluation board to a LAN with a router. You can also connect an evaluation board directly to a PC using a direct or crossover network cable.
 

--- a/Examples/Network/HTTP_Upload/README.md
+++ b/Examples/Network/HTTP_Upload/README.md
@@ -6,7 +6,7 @@ For detailed description see [HTTP Upload Example section in MDK-Middleware docu
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 To use this example, connect an evaluation board to a LAN with a router. You can also connect an evaluation board directly to a PC using a direct or crossover network cable.
 

--- a/Examples/Network/README.md
+++ b/Examples/Network/README.md
@@ -17,4 +17,4 @@
 
 For more details refer to [Network Examples section in the MDK-Middleware documentation](https://arm-software.github.io/MDK-Middleware/latest/Network/examples.html).
 
-Also see [CMSIS-Toolbox - Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.
+Also see [CMSIS-Toolbox - Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.

--- a/Examples/Network/SMTPS_Client/README.md
+++ b/Examples/Network/SMTPS_Client/README.md
@@ -6,7 +6,7 @@ For detailed description see [SMTPS Client Example section in MDK-Middleware doc
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 To use this example, connect the evaluation board to a LAN with a router. The example will automatically configure the network parameters.
 

--- a/Examples/Network/SMTP_Client/README.md
+++ b/Examples/Network/SMTP_Client/README.md
@@ -6,7 +6,7 @@ For detailed description see [SMTP Client Example section in MDK-Middleware docu
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections)to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 To use this example, connect the evaluation board to a LAN with a router. The example will automatically configure the network parameters.
 

--- a/Examples/Network/SNMP_Agent/README.md
+++ b/Examples/Network/SNMP_Agent/README.md
@@ -6,7 +6,7 @@ For detailed description see [SNMP Agent Example section in MDK-Middleware docum
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 To use this example, connect an evaluation board to a LAN with a DHCP server (most LANs have one). This example automatically configures the network parameters via a DHCP protocol.
 

--- a/Examples/Network/Telnet_Server/README.md
+++ b/Examples/Network/Telnet_Server/README.md
@@ -6,7 +6,7 @@ For detailed description see [Telnet Server Example section in MDK-Middleware do
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 To use this example, connect an evaluation board to a LAN with a router. You can also connect an evaluation board directly to a PC using a direct or crossover network cable.
 

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -2,6 +2,6 @@
 
 These MDK-Middleware examples demonstrate how to use MDK-Middleware software components in various application scenarios.
 
-The examples are implemented as [CMSIS-Toolbox Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md) that are hardware agnostic and require a board layer with drivers for the specific target hardware.
+The examples are implemented as [CMSIS-Toolbox Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/) that are hardware agnostic and require a board layer with drivers for the specific target hardware.
 
 For details see [Working with MDK-Middleware examples](https://arm-software.github.io/MDK-Middleware/latest/General/working_with_examples.html) in MDK-Middleware documentation.

--- a/Examples/USB/Device/HID/README.md
+++ b/Examples/USB/Device/HID/README.md
@@ -6,6 +6,6 @@ For detailed description see [USB Device HID Example section in MDK-Middleware d
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 A graphical **HID Client** program is available for the USB Host Computer (Windows only) to interface with the LEDs and buttons on the target USB Device.

--- a/Examples/USB/Device/MassStorage/README.md
+++ b/Examples/USB/Device/MassStorage/README.md
@@ -6,6 +6,6 @@ For detailed description see [USB Device MSC Example section in MDK-Middleware d
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 The implementation uses on-chip RAM as a storage device. The USB Host can access this memory drive using standard file access methods.

--- a/Examples/USB/Device/README.md
+++ b/Examples/USB/Device/README.md
@@ -10,4 +10,4 @@
 
 For more details refer to [USB Device Examples section in the MDK-Middleware documentation](https://arm-software.github.io/MDK-Middleware/latest/USB/usbd_examples.html).
 
-Also see [CMSIS-Toolbox - Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.
+Also see [CMSIS-Toolbox - Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.

--- a/Examples/USB/Device/VirtualCOM/README.md
+++ b/Examples/USB/Device/VirtualCOM/README.md
@@ -6,6 +6,6 @@ For detailed description see [USB Device Virtual COM Example section in MDK-Midd
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 The device enumerates on the USB Host as virtual communication port and can be accessed via a Terminal application.

--- a/Examples/USB/Host/Keyboard/README.md
+++ b/Examples/USB/Host/Keyboard/README.md
@@ -6,6 +6,6 @@ For detailed description see [USB Host Keyboard Example section in MDK-Middlewar
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 After the USB HID keyboard is connected to the development board, the pressed characters are forwarded to the standard output.

--- a/Examples/USB/Host/MassStorage/README.md
+++ b/Examples/USB/Host/MassStorage/README.md
@@ -6,7 +6,7 @@ For detailed description see [USB Host Mass Storage Example section in MDK-Middl
 
 ## Key usage aspects
 
-For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections) to the target hardware interfaces. For details see example documentation referenced above.
+For successful build and operation the project needs to be extended with a board layer that implements required [connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections) to the target hardware interfaces. For details see example documentation referenced above.
 
 This program creates (or overwrites) a `Test.txt` file on the connected USB Stick with the content:
 

--- a/Examples/USB/Host/README.md
+++ b/Examples/USB/Host/README.md
@@ -9,4 +9,4 @@
 
 For more details refer to [USB Host Examples section in the MDK-Middleware documentation](https://arm-software.github.io/MDK-Middleware/latest/USB/usbh_examples.html).
 
-Also see [CMSIS-Toolbox - Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.
+Also see [CMSIS-Toolbox - Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ The MDK-Middleware is annotated for the [CMSIS-View](https://arm-software.github
 - [ARM::CMSIS-Compiler](https://www.keil.arm.com/packs/cmsis-compiler-arm) version 2.0.0 or higher.
 - [ARM::CMSIS-View](https://www.keil.arm.com/packs/cmsis-view-arm) version 1.0.0 or higher.
 
-The MDK-Middleware examples use the *csolution project* format of the [CMSIS-Toolbox](https://github.com/Open-CMSIS-Pack/cmsis-toolbox) and are framed as [Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md) that require an additional software layer to run on an evaluation board. The CMSIS-Toolbox is developed under the [Open-CMSIS-Pack project](https://github.com/Open-CMSIS-Pack) and an integral part of several IDEs.
+The MDK-Middleware examples use the *csolution project* format of the [CMSIS-Toolbox](https://github.com/Open-CMSIS-Pack/cmsis-toolbox) and are framed as [Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/) that require an additional software layer to run on an evaluation board. The CMSIS-Toolbox is developed under the [Open-CMSIS-Pack project](https://github.com/Open-CMSIS-Pack) and an integral part of several IDEs.
 
 ### Using the development repository
 
-This development repository of the MDK-Middleware can be used in a local directory and [mapped as software pack](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/build-tools.md#install-a-repository) using for example `cpackget` with:
+This development repository of the MDK-Middleware can be used in a local directory and [mapped as software pack](https://open-cmsis-pack.github.io/cmsis-toolbox/build-tools#install-a-repository) using for example `cpackget` with:
 
     cpackget add <path>/Keil.MDK-Middleware.pdsc
 


### PR DESCRIPTION
Replaced references to https://github.com/Open-CMSIS-Pack/cmsis-toolbox/... to https://open-cmsis-pack.github.io/cmsis-toolbox/ a.o
[Issue 248](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/248)