### PR TITLE
Replaced references to https://github.com/Open-CMSIS-Pack/cmsis-toolbox

### DIFF
--- a/Validation/Projects/Network/README.md
+++ b/Validation/Projects/Network/README.md
@@ -6,4 +6,4 @@
 |-----------------------------------------------|-----------------------------------------------------------------------------------------------|
 | [BSD Sockets](./BSD_Sockets)                  | BSD Sockets Component validation.                                                             |
 
-Also see [CMSIS-Toolbox - Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.
+Also see [CMSIS-Toolbox - Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.

--- a/Validation/Projects/USB/Device/README.md
+++ b/Validation/Projects/USB/Device/README.md
@@ -9,4 +9,4 @@
 | [USB Device HID](./HID)                       | USB Device Human Interface Device (HID) Component validation.                                 |
 | [USB Device MSC](./MSC)                       | USB Device Mass Storage Class (MSC) device Component validation.                              |
 
-Also see [CMSIS-Toolbox - Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.
+Also see [CMSIS-Toolbox - Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.

--- a/Validation/Projects/USB/Host/README.md
+++ b/Validation/Projects/USB/Host/README.md
@@ -10,4 +10,4 @@
 | [USB Host MSC](./MSC)                         | USB Host Mass Storage Class (MSC) device Component validation.                                |
 | [USB Host MSC Performance](./MSC_Performance) | USB Host USB Flash Drive Performance (read/write speed) Measurement.                          |
 
-Also see [CMSIS-Toolbox - Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.
+Also see [CMSIS-Toolbox - Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/) to learn more about the concept of reference application in Open CMSIS Pack used by these examples.

--- a/Validation/README.md
+++ b/Validation/README.md
@@ -43,7 +43,7 @@ The selection and configuration of Components for testing is done via [MW_CV_Con
 ### Board layer
 
 In order to build the validation project it shall be extended with a compatible board layer that provides the following interfaces as
-[connections](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#connections):
+[connections](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#connections):
 
 - `CMSIS_ETH`:        CMSIS-Driver for Ethernet interface.
 - `CMSIS_MCI`:        CMSIS-Driver for MCI interface.


### PR DESCRIPTION
Replaced references to https://github.com/Open-CMSIS-Pack/cmsis-toolbox
with
https://open-cmsis-pack.github.io/cmsis-toolbox/