### PR TITLE
Remove comma from the last key-value pair

### DIFF
--- a/.ci/vcpkg-configuration.json
+++ b/.ci/vcpkg-configuration.json
@@ -13,6 +13,6 @@
         "arm:tools/arm/mdk-toolbox":" ^1.0.0",
         "arm:compilers/arm/armclang": "^6.22.0",
         "arm:compilers/arm/arm-none-eabi-gcc": "^13.2.1",
-        "arm:compilers/arm/llvm-embedded": "^18.1.3",
+        "arm:compilers/arm/llvm-embedded": "^18.1.3"
     }
 }


### PR DESCRIPTION
Remove comma from the last key-value pair
which is causing jq parsing errors:
"arm:compilers/arm/llvm-embedded": "^18.1.3"