### PR TITLE
Adding repository tag

### DIFF
--- a/Keil.MDK-Middleware.pdsc
+++ b/Keil.MDK-Middleware.pdsc
@@ -4,6 +4,7 @@
   <name>MDK-Middleware</name>
   <description overview="Documentation/README.md">Middleware for Arm based processors</description>
   <url>https://www.keil.com/pack/</url>
+  <repository type="git">https://github.com/ARM-software/MDK-Middleware.git</repository>
   <license>license_terms/license_agreement.txt</license>
   <licenseSets>
     <licenseSet id="all" default="true" gating="true">


### PR DESCRIPTION
Fix #124 
See specification: https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/element_repository.html
Note that the repository link will be displayed on the pack page 
https://www.keil.arm.com/packs/mdk-middleware-keil/overview/

Setting version tags should be added but unclear whether gen_pack is supporting this and I don't know whether this is rendered by the keil.arm.com.
