### PR TITLE
Security: Fix CVE-1999-0017 FTP bounce attack in net_ftp_server

### DIFF
--- a/Components/Network/Source/net_ftp_server.c
+++ b/Components/Network/Source/net_ftp_server.c
@@ -34,6 +34,10 @@ static netStatus ftp_dopen_req (NET_FTP_INFO *ftp_s);
 static NET_FTP_INFO *ftp_map_session (int32_t socket);
 static void ftp_kill_session (NET_FTP_INFO *ftp_s);
 static uint16_t ftp_scan_dport (const char *buf, uint8_t type);
+static bool ftp_parse_port_ip (const char *buf, uint8_t *ip);
+static bool ftp_parse_eprt_ip (const char *buf, uint8_t *ip);
+static bool ftp_validate_port_ip (const uint8_t *port_ip, const NET_ADDR *client_addr);
+static bool ftp_validate_port_range (uint16_t port);
 static char *make_path (NET_FTP_INFO *ftp_s, const char *name);
 static void free_name (NET_FTP_INFO *ftp_s);
 static void close_file (NET_FTP_INFO *ftp_s);
@@ -645,9 +649,50 @@ denied:       DEBUGF (FTP," Access denied\n");
           }
           if ((cmd.sel == FTP_CMD_PORT) ||
               (cmd.sel == FTP_CMD_EPRT)) {
-            /* Change FTP data port */
+            /* Change FTP data port, validate IP to prevent bounce attack */
+            uint8_t port_ip[4];
+            bool ip_valid;
+
+            /* Parse IP address from command */
+            if (cmd.sel == FTP_CMD_PORT) {
+              ip_valid = ftp_parse_port_ip ((const char *)&buf[5], port_ip);
+            }
+            else {
+              /* FTP_CMD_EPRT */
+              ip_valid = ftp_parse_eprt_ip ((const char *)&buf[5], port_ip);
+            }
+
+            if (ip_valid == false) {
+              /* Failed to parse IP from command */
+              ERRORF (FTP,"Session %d, %s format invalid\n",ftp_s->Id,
+                      (cmd.sel == FTP_CMD_PORT) ? "PORT" : "EPRT");
+              /* EvrNetFTPs_InvalidCommandFormat (ftp_s->Id, cmd.sel); */
+              ftp_s->Resp = FTP_RESP_BADPARAM;
+              break;
+            }
+
+            /* Validate IP matches client (RFC 2577 - prevent bounce attack) */
+            if (ftp_validate_port_ip (port_ip, &ftp_s->Client) == false) {
+              /* IP mismatch, FTP bounce attack attempt (CVE-1999-0017) */
+              ERRORF (FTP,"Session %d, Bounce attack blocked\n",ftp_s->Id);
+              /* EvrNetFTPs_BounceAttackBlocked (ftp_s->Id); */
+              ftp_s->Resp = FTP_RESP_NOTIMPL;
+              break;
+            }
+
+            /* Extract and validate port number */
             net_tcp_abort (ftp_s->DSocket);
             ftp_s->DPort = ftp_scan_dport ((const char *)&buf[5], cmd.sel);
+
+            if (ftp_validate_port_range (ftp_s->DPort) == false) {
+              /* Invalid port number */
+              ERRORF (FTP,"Session %d, Invalid port\n",ftp_s->Id);
+              /* EvrNetFTPs_InvalidPort (ftp_s->Id, ftp_s->DPort); */
+              ftp_s->Resp = FTP_RESP_BADPARAM;
+              break;
+            }
+
+            /* All validations passed */
             DEBUGF (FTP," Data port is %d\n",ftp_s->DPort);
             EvrNetFTPs_ActiveModeStart (ftp_s->Id, ftp_s->DPort);
             ftp_s->Flags &= ~FTP_FLAG_PASSIVE;
@@ -1165,6 +1210,9 @@ static void ftp_server_run (void) {
         case FTP_RESP_USERFIRST:
           len = LSTR(tp,"503 Login with USER first\r\n");
           break;
+        case FTP_RESP_NOTIMPL:
+          len = LSTR(tp,"504 Command not implemented for that parameter\r\n");
+          break;
         case FTP_RESP_LOGINFAIL:
           len = LSTR(tp,"530 Login incorrect\r\n");
           break;
@@ -1185,6 +1233,9 @@ static void ftp_server_run (void) {
           break;
         case FTP_RESP_DISKFULL:
           len = LSTR(tp,"552 Exceeded storage allocation\r\n");
+          break;
+        case FTP_RESP_BADPARAM:
+          len = LSTR(tp,"501 Syntax error in parameters\r\n");
           break;
         default:
           len = LSTR(tp,"500 Unknown command\r\n");
@@ -1595,6 +1646,151 @@ static NET_FTP_INFO *ftp_map_session (int32_t socket) {
     }
   }
   return (NULL);
+}
+
+/**
+  \brief       Parse IP address from PORT command.
+  \param[in]   buf  buffer containing PORT command parameters.
+  \param[out]  ip   extracted IP address (4 bytes).
+  \return      status:
+               - true  = IP address parsed successfully
+               - false = invalid format
+  \note        PORT format: "h1,h2,h3,h4,p1,p2" (RFC 959)
+*/
+static bool ftp_parse_port_ip (const char *buf, uint8_t *ip) {
+  uint32_t h1,h2,h3,h4,p1,p2;
+  int32_t n,len;
+
+  /* Parse PORT parameters: h1,h2,h3,h4,p1,p2 */
+  n  = net_atoi (buf, &len);
+  h1 = (uint32_t)n; buf += len + 1;
+  n  = net_atoi (buf, &len);
+  h2 = (uint32_t)n; buf += len + 1;
+  n  = net_atoi (buf, &len);
+  h3 = (uint32_t)n; buf += len + 1;
+  n  = net_atoi (buf, &len);
+  h4 = (uint32_t)n; buf += len + 1;
+  n  = net_atoi (buf, &len);
+  p1 = (uint32_t)n; buf += len + 1;
+  n  = net_atoi (buf, &len);
+  p2 = (uint32_t)n;
+
+  /* Validate IP address components (0-255) */
+  if ((h1 > 255) || (h2 > 255) || (h3 > 255) || (h4 > 255)) {
+    return (false);
+  }
+
+  /* Store IP address */
+  ip[0] = (uint8_t)h1;
+  ip[1] = (uint8_t)h2;
+  ip[2] = (uint8_t)h3;
+  ip[3] = (uint8_t)h4;
+  return (true);
+}
+
+/**
+  \brief       Parse IP address from EPRT command.
+  \param[in]   buf  buffer containing EPRT command parameters.
+  \param[out]  ip   extracted IP address (4 bytes for IPv4).
+  \return      status:
+               - true  = IP address parsed successfully
+               - false = invalid format or unsupported address family
+  \note        EPRT IPv4 format: "|1|h1.h2.h3.h4|port|" (RFC 2428)
+*/
+static bool ftp_parse_eprt_ip (const char *buf, uint8_t *ip) {
+  char delim;
+  uint32_t h1,h2,h3,h4;
+  int32_t family,i,j;
+
+  /* Parse delimiter and address family */
+  delim = buf[0];
+  if ((delim == 0) || (buf[1] < '1') || (buf[1] > '2')) {
+    return (false);
+  }
+  family = buf[1] - '0';
+
+  /* Only IPv4 (family 1) is supported */
+  if (family != 1) {
+    return (false);
+  }
+
+  /* Find IP address between 2nd and 3rd delimiters */
+  for (i = 2; buf[i] != 0; i++) {
+    if (buf[i] == delim) break;
+  }
+  if (buf[i] != delim) {
+    return (false);
+  }
+
+  /* Parse IPv4 address: h1.h2.h3.h4 */
+  i++;
+  h1 = 0;
+  for (j = 0; j < 4; j++) {
+    h2 = 0;
+    while ((buf[i] >= '0') && (buf[i] <= '9')) {
+      h2 = h2 * 10 + (uint32_t)(buf[i] - '0');
+      i++;
+    }
+    if (h2 > 255) {
+      return (false);
+    }
+    ip[j] = (uint8_t)h2;
+    if (j < 3) {
+      if (buf[i] != '.') {
+        return (false);
+      }
+      i++;
+    }
+  }
+  return (buf[i] == delim);
+}
+
+/**
+  \brief       Validate PORT/EPRT IP address matches client IP.
+  \param[in]   port_ip       IP address from PORT/EPRT command.
+  \param[in]   client_addr   client connection address.
+  \return      status:
+               - true  = IP address matches client (legitimate)
+               - false = IP mismatch (bounce attack attempt)
+  \note        Implements RFC 2577 security requirement to prevent
+               FTP bounce attacks (CVE-1999-0017).
+*/
+static bool ftp_validate_port_ip (const uint8_t *port_ip, const NET_ADDR *client_addr) {
+
+  if (client_addr->addr_type != NET_ADDR_IP4) {
+    /* Only IPv4 supported */
+    return (false);
+  }
+
+  /* Compare IP address (4 bytes) */
+  if (memcmp (port_ip, client_addr->addr, 4) != 0) {
+    /* IP mismatch detected, potential bounce attack */
+    ERRORF (FTP,"PORT IP mismatch, client=%d.%d.%d.%d, requested=%d.%d.%d.%d\n",
+            client_addr->addr[0], client_addr->addr[1], 
+            client_addr->addr[2], client_addr->addr[3],
+            port_ip[0], port_ip[1], port_ip[2], port_ip[3]);
+    /* EvrNetFTPs_PortIpMismatch (port_ip, client_addr->addr); */
+    return (false);
+  }
+  return (true);
+}
+
+/**
+  \brief       Validate port number is in valid range.
+  \param[in]   port  port number to validate.
+  \return      status:
+               - true  = port number is valid
+               - false = port number out of range
+  \note        Valid port range is 1-65535 per RFC 959.
+*/
+static bool ftp_validate_port_range (uint16_t port) {
+
+  if ((port == 0) || (port > 65535)) {
+    ERRORF (FTP,"Invalid port number: %d\n",port);
+    /* EvrNetFTPs_InvalidPortNumber (port); */
+    return (false);
+  }
+  return (true);
 }
 
 /**

--- a/Components/Network/Source/net_ftp_server.h
+++ b/Components/Network/Source/net_ftp_server.h
@@ -106,6 +106,8 @@
 #define FTP_RESP_EPSVOK     26          // Entering Extended Passive mode
 #define FTP_RESP_FEAT       27          // Print supported extended features
 #define FTP_RESP_CWDERR     28          // Change working directory failed
+#define FTP_RESP_BADPARAM   29          // Syntax error in parameters
+#define FTP_RESP_NOTIMPL    30          // Command not implemented for parameter
 
 /* FTP Command type */
 typedef struct net_ftp_ctype {


### PR DESCRIPTION
### Summary

The FTP server in MDK-Middleware does not validate whether the IP address provided in PORT and EPRT commands matches the IP of the connected client. This allows any authenticated user to instruct the server to open data connections toward arbitrary third-party hosts, which is a well-known attack vector documented as CVE-1999-0017.

This patch adds IP validation to the PORT/EPRT handler in `net_ftp_server.c`, rejecting commands that specify an IP address different from the client's. It follows the recommendation in RFC 2577, Section 3.

### The problem

When a client sends a PORT command, the current implementation extracts only the port number via `ftp_scan_dport()` and immediately responds `200 Command okay`, regardless of what IP address the command contains. The IP portion of the argument is never checked against the client's actual address.

In practice, this means an attacker who is authenticated on the FTP server can do the following:

```
$ ftp 192.168.1.50
> USER myuser
> PASS mypass
230 User logged in.
> PORT 8,8,8,8,0,80
200 Command okay.
> LIST
```

At this point the FTP server opens a TCP connection from its own address to 8.8.8.8 on port 80. The attacker never touches 8.8.8.8 directly -- the server does it on their behalf. This is the FTP bounce attack.

The same applies to EPRT:

```
> EPRT |1|10.0.0.5|22|
200 Command okay.
```

The server would then connect to an internal machine at 10.0.0.5 on the SSH port.

This lets an attacker:

- Scan ports on internal machines behind the firewall (using loopback 127.0.0.1 or private addresses like 10.x.x.x, 192.168.x.x).
- Relay traffic through the FTP server to reach hosts that the attacker cannot contact directly.
- Obscure the origin of connections, since they appear to come from the FTP server's IP.

This class of vulnerability is catalogued as [CWE-441: Unintended Proxy or Intermediary](https://cwe.mitre.org/data/definitions/441.html), which specifically lists CVE-1999-0017 as an observed example.

### How to reproduce

You need an FTP client (or just a raw TCP socket) and access to a running MDK-Middleware FTP server. Python's `ftplib` is enough:

```python
import ftplib

ftp = ftplib.FTP()
ftp.connect("192.168.1.50", 21)     # your FTP server
ftp.login("user", "pass")

# Ask the server to connect to an external host
resp = ftp.sendcmd("PORT 8,8,8,8,0,80")
print(resp)  # "200 Command okay" means the server accepted it -- vulnerable
```

If the server responds with `200`, it will attempt to open a data connection to 8.8.8.8:80 on the next transfer command. A fixed server should respond with `504 Command not implemented for that parameter`.

Additional cases to test:

| Command                           | Expected (fixed) | Reason                      |
|-----------------------------------|-------------------|-----------------------------|
| `PORT 8,8,8,8,0,80`              | 504               | External IP, bounce attack  |
| `PORT 127,0,0,1,0,22`            | 504               | Loopback, port scan         |
| `PORT 192,168,204,1,0,23`        | 504               | Different private IP        |
| `EPRT \|1\|8.8.8.8\|80\|`        | 504               | EPRT bounce variant         |
| `PORT <client_ip>,195,88`        | 200               | Legitimate, own IP          |

### What this patch does

**Files changed:**
- `Components/Network/Source/net_ftp_server.c` (4 functions added, PORT/EPRT handler modified)
- `Components/Network/Source/net_ftp_server.h` (2 response codes added)

The patch introduces four static helper functions before `ftp_listener()`:

1. `ftp_parse_port_ip()` -- parses the IP address from PORT command arguments (`h1,h2,h3,h4,p1,p2`), using the existing `net_atoi()` function. Validates that each octet is in the 0-255 range.

2. `ftp_parse_eprt_ip()` -- parses the IP address from EPRT command arguments (`|1|addr|port|`), following the format specified in RFC 2428. Currently supports IPv4 only (address family 1).

3. `ftp_validate_port_ip()` -- compares the parsed IP against `ftp_s->Client.addr` using `memcmp()`. Returns false and logs with `ERRORF()` when there is a mismatch.

4. `ftp_validate_port_range()` -- validates that the port number falls within the 1-65535 range.

The PORT/EPRT handler in `ftp_listener()` is modified to call these functions before accepting the command. If parsing fails, the server responds with `501 Syntax error in parameters`. If the IP does not match the client's address, it responds with `504 Command not implemented for that parameter`. Both codes are standard FTP response codes defined in RFC 959.

Two new response code constants are added to the header:
- `FTP_RESP_BADPARAM` (maps to 501)
- `FTP_RESP_NOTIMPL` (maps to 504)

### Backward compatibility

This change does not affect legitimate FTP clients. Any client that uses PORT or EPRT with its own IP address (which is the normal behavior) will continue to work exactly as before. Clients using PASV or EPSV are not affected at all.

The only traffic that gets rejected is PORT/EPRT commands where the specified IP does not match the client's connection -- something that only happens intentionally (i.e., an attack or proxy FTP). Proxy FTP through third-party PORT commands is explicitly discouraged by RFC 2577.

### References

- **CVE-1999-0017** -- "FTP servers can allow an attacker to connect to arbitrary ports on machines other than the FTP client, aka FTP bounce."
  https://www.cve.org/CVERecord?id=CVE-1999-0017

- **RFC 2577** -- FTP Security Considerations (Allman, Ostermann, May 1999). Section 3 describes the bounce attack and recommends that servers reject PORT commands specifying third-party addresses, using response code 504.
  https://datatracker.ietf.org/doc/html/rfc2577

- **RFC 959** -- File Transfer Protocol (Postel, Reynolds, October 1985). Defines PORT command format and response codes 501 and 504.
  https://datatracker.ietf.org/doc/html/rfc959

- **RFC 2428** -- FTP Extensions for IPv6 and NATs (Allman, Ostermann, Metz, September 1998). Defines the EPRT command format.
  https://datatracker.ietf.org/doc/html/rfc2428

- **CWE-441** -- Unintended Proxy or Intermediary ('Confused Deputy'). Lists CVE-1999-0017 as an observed example of this weakness class.
  https://cwe.mitre.org/data/definitions/441.html

- **CERT Advisory CA-97.27** -- FTP Bounce. Referenced in RFC 2577.

---

## Implementation Status

- [x] Fork created: https://github.com/jmrplens/MDK-Middleware_ftp_security
- [x] Branch: `fix/cve-1999-0017-ftp-bounce`
- [x] Commits:
  - `1ff81bf` -- Security: Fix CVE-1999-0017 FTP bounce attack in net_ftp_server
- [x] Compiled successfully with Keil Compiler 6
- [x] Security tests pass on real hardware (10/10)
- [ ] Review by maintainers
