### PR TITLE
FileSystem: correct funmount for FAT drives when called multiple times

### DIFF
--- a/Components/FileSystem/FileSystem.scvd
+++ b/Components/FileSystem/FileSystem.scvd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <component_viewer schemaVersion="0.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="Component_Viewer.xsd">
-  <component name="File System" shortname="FS" version="8.0.3"/>    <!-- name and version of the component  -->
+  <component name="File System" shortname="FS" version="8.0.4"/>    <!-- name and version of the component  -->
 
   <typedefs>
     <!-- Flash Sector information (Driver_Flash.h line 58) -->

--- a/Components/FileSystem/Include/rl_fs.h
+++ b/Components/FileSystem/Include/rl_fs.h
@@ -14,7 +14,7 @@
 
 #define MW_FS_VERSION_MAJOR      8
 #define MW_FS_VERSION_MINOR      0
-#define MW_FS_VERSION_PATCH      3
+#define MW_FS_VERSION_PATCH      4
 
 // ==== Enumeration, structures, defines ====
 

--- a/Components/FileSystem/Source/fs_fat.c
+++ b/Components/FileSystem/Source/fs_fat.c
@@ -4349,7 +4349,9 @@ __WEAK fsStatus fat_unmount (fsFAT_Volume *vol) {
     }
   }
   /* Uninitialize media */
-  vol->Drv->UnInit (DM_MEDIA);
+  if (vol->Drv != NULL) {
+    vol->Drv->UnInit (DM_MEDIA);
+  }
   /* Update volume status */
   vol->Status &= ~(FAT_STATUS_MOUNT | FAT_STATUS_INIT_MEDIA);
 

--- a/Documentation/Doxygen/FileSystem/src/revision_history.md
+++ b/Documentation/Doxygen/FileSystem/src/revision_history.md
@@ -6,6 +6,12 @@
       <th>Description</th>
     </tr>
     <tr>
+      <td>V8.0.4</td>
+      <td>
+        - corrected funmount for FAT drives when called multiple times
+      </td>
+    </tr>
+    <tr>
       <td>V8.0.3</td>
       <td>
         - corrected output format in file seek debug events

--- a/Documentation/Doxygen/General/src/revision_history.md
+++ b/Documentation/Doxygen/General/src/revision_history.md
@@ -13,7 +13,7 @@
     <td>V8.3.1</td>
     <td>
       - Network Component Version 8.3.1
-      - FileSystem Component Version 8.0.3 (unchanged)
+      - FileSystem Component Version 8.0.4
       - USB Component Version 8.0.2 (unchanged)
     </td>
   </tr>

--- a/Keil.MDK-Middleware.pdsc
+++ b/Keil.MDK-Middleware.pdsc
@@ -14,6 +14,8 @@
   <releases>
     <release version="8.3.1-dev">
       Active development ...
+      FileSystem Component Version 8.0.4
+      - corrected funmount for FAT drives when called multiple times
       Network Component Version 8.3.1
       - fixed possible TCP socket reset after timeout recovery
       - various minor fixes and security improvements
@@ -1160,7 +1162,7 @@
     </bundle>
 
     <!-- File System (MDK) -->
-    <bundle Cbundle="MDK" Cclass="File System" Cversion="8.0.3">
+    <bundle Cbundle="MDK" Cclass="File System" Cversion="8.0.4">
       <description>File Access on various storage devices</description>
       <doc>Documentation/html/FileSystem/index.html</doc>
       <component Cgroup="CORE" condition="CMSIS Core with RTOS and File System I/O">


### PR DESCRIPTION
- Prevents a fault caused by dereferencing a NULL driver pointer