### PR TITLE
FileSystem: corrected FAT name cache entry size from 48 to 40 bytes

### DIFF
--- a/.ci/FileSystem/RTE/File_System/FS_Config_MC_0.h
+++ b/.ci/FileSystem/RTE/File_System/FS_Config_MC_0.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System:Drive
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    FS_Config_MC_0.h
  * Purpose: File System Configuration for Memory Card Drive
@@ -46,7 +46,7 @@
 //   </e>
 //   <o>Filename Cache Size <0-1000000>
 //   <i>Define number of cached file or directory names.
-//   <i>48 bytes of RAM is required for each cached name.
+//   <i>40 bytes of RAM is required for each cached name.
 #define MC0_NAME_CACHE_SIZE     0
 
 //   <q>Use FAT Journal

--- a/.ci/FileSystem/RTE/File_System/FS_Config_MC_1.h
+++ b/.ci/FileSystem/RTE/File_System/FS_Config_MC_1.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System:Drive
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    FS_Config_MC_1.h
  * Purpose: File System Configuration for Memory Card Drive
@@ -46,7 +46,7 @@
 //   </e>
 //   <o>Filename Cache Size <0-1000000>
 //   <i>Define number of cached file or directory names.
-//   <i>48 bytes of RAM is required for each cached name.
+//   <i>40 bytes of RAM is required for each cached name.
 #define MC1_NAME_CACHE_SIZE     0
 
 //   <q>Use FAT Journal

--- a/.ci/FileSystem/RTE/File_System/FS_Config_NAND_0.h
+++ b/.ci/FileSystem/RTE/File_System/FS_Config_NAND_0.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System:Drive
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    FS_Config_NAND_0.h
  * Purpose: File System Configuration for NAND Flash Drive
@@ -142,7 +142,7 @@
 //   </e>
 //   <o>Filename Cache Size <0-1000000>
 //   <i>Define number of cached file or directory names.
-//   <i>48 bytes of RAM is required for each cached name.
+//   <i>40 bytes of RAM is required for each cached name.
 #define NAND0_NAME_CACHE_SIZE   0
 
 //   <q>Use FAT Journal

--- a/.ci/FileSystem/RTE/File_System/FS_Config_NAND_1.h
+++ b/.ci/FileSystem/RTE/File_System/FS_Config_NAND_1.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System:Drive
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    FS_Config_NAND_1.h
  * Purpose: File System Configuration for NAND Flash Drive
@@ -142,7 +142,7 @@
 //   </e>
 //   <o>Filename Cache Size <0-1000000>
 //   <i>Define number of cached file or directory names.
-//   <i>48 bytes of RAM is required for each cached name.
+//   <i>40 bytes of RAM is required for each cached name.
 #define NAND1_NAME_CACHE_SIZE   0
 
 //   <q>Use FAT Journal

--- a/.ci/FileSystem/RTE/File_System/FS_Config_USB_0.h
+++ b/.ci/FileSystem/RTE/File_System/FS_Config_USB_0.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System:Drive
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    FS_Config_USB_0.h
  * Purpose: File System Configuration for USB Drive
@@ -22,7 +22,7 @@
 
 //   <o>Filename Cache Size <0-1000000>
 //   <i>Define number of cached file or directory names.
-//   <i>48 bytes of RAM is required for each cached name.
+//   <i>40 bytes of RAM is required for each cached name.
 #define USB0_NAME_CACHE_SIZE    0
 
 //   <q>Use FAT Journal

--- a/.ci/FileSystem/RTE/File_System/FS_Config_USB_1.h
+++ b/.ci/FileSystem/RTE/File_System/FS_Config_USB_1.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System:Drive
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    FS_Config_USB_1.h
  * Purpose: File System Configuration for USB Drive
@@ -22,7 +22,7 @@
 
 //   <o>Filename Cache Size <0-1000000>
 //   <i>Define number of cached file or directory names.
-//   <i>48 bytes of RAM is required for each cached name.
+//   <i>40 bytes of RAM is required for each cached name.
 #define USB1_NAME_CACHE_SIZE    0
 
 //   <q>Use FAT Journal

--- a/Components/FileSystem/Config/FS_Config_MC.h
+++ b/Components/FileSystem/Config/FS_Config_MC.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System:Drive
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    FS_Config_MC_%Instance%.h
  * Purpose: File System Configuration for Memory Card Drive
@@ -46,7 +46,7 @@
 //   </e>
 //   <o>Filename Cache Size <0-1000000>
 //   <i>Define number of cached file or directory names.
-//   <i>48 bytes of RAM is required for each cached name.
+//   <i>40 bytes of RAM is required for each cached name.
 #define MC%Instance%_NAME_CACHE_SIZE     0
 
 //   <q>Use FAT Journal

--- a/Components/FileSystem/Config/FS_Config_NAND.h
+++ b/Components/FileSystem/Config/FS_Config_NAND.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System:Drive
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    FS_Config_NAND_%Instance%.h
  * Purpose: File System Configuration for NAND Flash Drive
@@ -142,7 +142,7 @@
 //   </e>
 //   <o>Filename Cache Size <0-1000000>
 //   <i>Define number of cached file or directory names.
-//   <i>48 bytes of RAM is required for each cached name.
+//   <i>40 bytes of RAM is required for each cached name.
 #define NAND%Instance%_NAME_CACHE_SIZE   0
 
 //   <q>Use FAT Journal

--- a/Components/FileSystem/Config/FS_Config_USB.h
+++ b/Components/FileSystem/Config/FS_Config_USB.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System:Drive
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    FS_Config_USB_%Instance%.h
  * Purpose: File System Configuration for USB Drive
@@ -22,7 +22,7 @@
 
 //   <o>Filename Cache Size <0-1000000>
 //   <i>Define number of cached file or directory names.
-//   <i>48 bytes of RAM is required for each cached name.
+//   <i>40 bytes of RAM is required for each cached name.
 #define USB%Instance%_NAME_CACHE_SIZE    0
 
 //   <q>Use FAT Journal

--- a/Components/FileSystem/FileSystem.scvd
+++ b/Components/FileSystem/FileSystem.scvd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <component_viewer schemaVersion="0.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="Component_Viewer.xsd">
-  <component name="File System" shortname="FS" version="8.0.4"/>    <!-- name and version of the component  -->
+  <component name="File System" shortname="FS" version="8.0.5"/>    <!-- name and version of the component  -->
 
   <typedefs>
     <!-- Flash Sector information (Driver_Flash.h line 58) -->

--- a/Components/FileSystem/Include/rl_fs.h
+++ b/Components/FileSystem/Include/rl_fs.h
@@ -14,7 +14,7 @@
 
 #define MW_FS_VERSION_MAJOR      8
 #define MW_FS_VERSION_MINOR      0
-#define MW_FS_VERSION_PATCH      4
+#define MW_FS_VERSION_PATCH      5
 
 // ==== Enumeration, structures, defines ====
 

--- a/Components/FileSystem/Source/fs_config.c
+++ b/Components/FileSystem/Source/fs_config.c
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    fs_config.h
  * Purpose: File System Library Configuration
@@ -265,7 +265,7 @@ uint8_t const fs_efs_fh_cnt = EFS_MAX_OPEN_FILES;
 uint8_t const fs_ndrv = FS_NDRV;
 
  /* FAT Name Cache definitions */
-#define FAT_NCACHE_LINK_SZ  (48)
+#define FAT_NCACHE_LINK_SZ  (40)
 #define FAT_NCACHE_STAT_SZ  (20)
 #define FAT_NCACHE_USED_SZ  (8)
 

--- a/Components/FileSystem/Source/fs_fat_elink.h
+++ b/Components/FileSystem/Source/fs_fat_elink.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    fs_fat_elink.h
  * Purpose: FAT File System Entry Link Cache definitions
@@ -50,10 +50,8 @@ typedef struct __elink_info {
 } ELINK_INFO;
 
 
-/* Cached file entry link (48 bytes) */
+/* Cached file entry link (40 bytes) */
 typedef struct __elink {
-  struct __elink *Back;                 /* Back link                          */
-  struct __elink *Forw;                 /* Forward link                       */
   struct __elink *Prev;                 /* Previous link                      */
   struct __elink *Next;                 /* Next link                          */
   ELINK_DEL  Del;                       /* Entry link delete list             */

--- a/Documentation/Doxygen/FileSystem/src/resource_requirements.md
+++ b/Documentation/Doxygen/FileSystem/src/resource_requirements.md
@@ -111,7 +111,7 @@ on compiler optimizations and target processor and may be therefore slightly dif
 | **File System:Core** EFS (Embedded File System)      |    < 6.0 k        | < 0.4 k
 | **File System:Core** FAT with SFN (Short File Name)  |   < 13.0 k        | 1.2 k
 | **File System:Core** FAT with LFN (Long File Name)   |   < 14.4 k        | 1.2 k
-| **File System:Core** FAT Name caching                |      1.6 k        | 48 x *FAT Name Cache Size* (configured in `FS_Config_Drive_n.h`)
+| **File System:Core** FAT Name caching                |      1.6 k        | 40 x *FAT Name Cache Size* (configured in `FS_Config_Drive_n.h`)
 | **File System:Core** FAT Journaling                  |      0.7 k        | 0.5 k (configured in `FS_Config_Drive_n.h`)
 | **File System:Drive:Memory Card** (FAT)              |      2.7 k        | < 0.2 k + *Drive Cache Size* (configured in `FS_Config_MC_n.h`)
 | **File System:Drive:NAND** (FAT)                     |   < 10.6 k        | < 0.7 k + *Drive Cache Size* + *Page Caching* + *Block Indexing* (configured in `FS_Config_NAND_n.h`)

--- a/Documentation/Doxygen/FileSystem/src/revision_history.md
+++ b/Documentation/Doxygen/FileSystem/src/revision_history.md
@@ -6,9 +6,10 @@
       <th>Description</th>
     </tr>
     <tr>
-      <td>V8.0.4</td>
+      <td>V8.0.5</td>
       <td>
         - corrected funmount for FAT drives when called multiple times
+        - corrected FAT name cache entry size from 48 to 40 bytes
       </td>
     </tr>
     <tr>

--- a/Documentation/Doxygen/General/src/revision_history.md
+++ b/Documentation/Doxygen/General/src/revision_history.md
@@ -13,7 +13,7 @@
     <td>V8.3.1</td>
     <td>
       - Network Component Version 8.3.1
-      - FileSystem Component Version 8.0.4
+      - FileSystem Component Version 8.0.5
       - USB Component Version 8.0.2 (unchanged)
     </td>
   </tr>

--- a/Examples/FileSystem/File_Demo/RTE/File_System/FS_Config_MC_0.h
+++ b/Examples/FileSystem/File_Demo/RTE/File_System/FS_Config_MC_0.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System:Drive
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    FS_Config_MC_0.h
  * Purpose: File System Configuration for Memory Card Drive
@@ -53,7 +53,7 @@
 //   </e>
 //   <o>Filename Cache Size <0-1000000>
 //   <i>Define number of cached file or directory names.
-//   <i>48 bytes of RAM is required for each cached name.
+//   <i>40 bytes of RAM is required for each cached name.
 #define MC0_NAME_CACHE_SIZE     0
 
 //   <q>Use FAT Journal

--- a/Examples/Network/FTP_Server/RTE/File_System/FS_Config_MC_0.h
+++ b/Examples/Network/FTP_Server/RTE/File_System/FS_Config_MC_0.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System:Drive
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    FS_Config_MC_0.h
  * Purpose: File System Configuration for Memory Card Drive
@@ -53,7 +53,7 @@
 //   </e>
 //   <o>Filename Cache Size <0-1000000>
 //   <i>Define number of cached file or directory names.
-//   <i>48 bytes of RAM is required for each cached name.
+//   <i>40 bytes of RAM is required for each cached name.
 #define MC0_NAME_CACHE_SIZE     0
 
 //   <q>Use FAT Journal

--- a/Examples/Network/HTTP_Upload/RTE/File_System/FS_Config_MC_0.h
+++ b/Examples/Network/HTTP_Upload/RTE/File_System/FS_Config_MC_0.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System:Drive
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    FS_Config_MC_0.h
  * Purpose: File System Configuration for Memory Card Drive
@@ -53,7 +53,7 @@
 //   </e>
 //   <o>Filename Cache Size <0-1000000>
 //   <i>Define number of cached file or directory names.
-//   <i>48 bytes of RAM is required for each cached name.
+//   <i>40 bytes of RAM is required for each cached name.
 #define MC0_NAME_CACHE_SIZE     0
 
 //   <q>Use FAT Journal

--- a/Examples/USB/Host/MassStorage/RTE/File_System/FS_Config_USB_0.h
+++ b/Examples/USB/Host/MassStorage/RTE/File_System/FS_Config_USB_0.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System:Drive
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    FS_Config_USB_0.h
  * Purpose: File System Configuration for USB Drive
@@ -22,7 +22,7 @@
 
 //   <o>Filename Cache Size <0-1000000>
 //   <i>Define number of cached file or directory names.
-//   <i>48 bytes of RAM is required for each cached name.
+//   <i>40 bytes of RAM is required for each cached name.
 #define USB0_NAME_CACHE_SIZE    0
 
 //   <q>Use FAT Journal

--- a/Keil.MDK-Middleware.pdsc
+++ b/Keil.MDK-Middleware.pdsc
@@ -14,8 +14,9 @@
   <releases>
     <release version="8.3.1-dev">
       Active development ...
-      FileSystem Component Version 8.0.4
+      FileSystem Component Version 8.0.5
       - corrected funmount for FAT drives when called multiple times
+      - corrected FAT name cache entry size from 48 to 40 bytes
       Network Component Version 8.3.1
       - fixed possible TCP socket reset after timeout recovery
       - various minor fixes and security improvements
@@ -1162,7 +1163,7 @@
     </bundle>
 
     <!-- File System (MDK) -->
-    <bundle Cbundle="MDK" Cclass="File System" Cversion="8.0.4">
+    <bundle Cbundle="MDK" Cclass="File System" Cversion="8.0.5">
       <description>File Access on various storage devices</description>
       <doc>Documentation/html/FileSystem/index.html</doc>
       <component Cgroup="CORE" condition="CMSIS Core with RTOS and File System I/O">


### PR DESCRIPTION
- removes unused Back and Forw pointers from ELINK structure, hence reduces structure size from 48 to 40 bytes
- updates all references to that size