### PR TITLE
FileSystem: clean-up the ffind wrapper

### DIFF
--- a/Components/FileSystem/Source/fs_config.c
+++ b/Components/FileSystem/Source/fs_config.c
@@ -1744,7 +1744,7 @@ int __wrap_fflush (FILE *stream) {
  fsStatus efs_flush (int32_t h)                                    { (void)h;                   return (fsError); }
  int32_t  efs_flen  (int32_t h)                                    { (void)h;                   return (-1);      }
  int32_t  efs_seek  (int32_t h, int32_t o, int32_t w)              { (void)h; (void)o; (void)w; return (fsError); }
- fsStatus efs_ffind (fsFileInfo *i, fsEFS_Volume *v)               { (void)i; (void)v;          return (fsError); }
+ fsStatus efs_ffind (const char *p, fsFileInfo *i, fsEFS_Volume *v){ (void)p; (void)i; (void)v; return (fsError); }
  fsStatus efs_rename(const char *p, const char *n, fsEFS_Volume *v){ (void)p; (void)n; (void)v; return (fsError); }
  fsStatus efs_delete(const char *p, fsEFS_Volume *v)               { (void)p; (void)v;          return (fsError); }
  int32_t  efs_analyse(fsEFS_Volume *v)                             { (void)v;                   return (0);       }

--- a/Components/FileSystem/Source/fs_core_lib.h
+++ b/Components/FileSystem/Source/fs_core_lib.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::File System
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    fs_core_lib.h
  * Purpose: File System Library Definitions
@@ -261,7 +261,7 @@ extern int32_t  efs_seek      (int32_t handle, int32_t offset, int32_t whence);
 
 /* EFS Maintenance Routines */
 extern fsStatus efs_delete    (const char *filename, fsEFS_Volume *vol);
-extern fsStatus efs_ffind     (fsFileInfo *info, fsEFS_Volume *vol);
+extern fsStatus efs_ffind     (const char *filename, fsFileInfo *info, fsEFS_Volume *vol);
 extern fsStatus efs_rename    (const char *filename, const char *newname, fsEFS_Volume *vol);
 
 /* EFS Utility Routines */

--- a/Components/FileSystem/Source/fs_efs.c
+++ b/Components/FileSystem/Source/fs_efs.c
@@ -2269,18 +2269,22 @@ __WEAK fsStatus efs_delete (const char *path, fsEFS_Volume *vol) {
 
 
 /**
-  Searches for the file with next file ID.
+  Find a file matching the requested pattern.
 
-  \param[in]  handle                    file handle
-  \param[in]  info                      file information structure
+  \param[in]  fn                        file search pattern
+  \param[out] info                      file information structure
+  \param[in]  vol                       volume description structure
   \return     execution status \ref fsStatus
 */
-__WEAK fsStatus efs_ffind (fsFileInfo *info, fsEFS_Volume *vol) {
+__WEAK fsStatus efs_ffind (const char *fn, fsFileInfo *info, fsEFS_Volume *vol) {
   FALLOC fa;
   uint32_t block, addr;
-  uint32_t nid, id, id_block = 0U;
-  uint32_t prev, fn_addr = 0U;
+  uint32_t nid, id, id_block;
+  uint32_t prev, fn_addr;
   fsStatus stat;
+  int32_t  prefix_len;
+  uint32_t suffix_len;
+  uint32_t pattern_len;
 
   if (info == NULL) {
     /* Invalid parameter */
@@ -2293,74 +2297,101 @@ __WEAK fsStatus efs_ffind (fsFileInfo *info, fsEFS_Volume *vol) {
     return (stat);
   }
 
-  /* Initialize next and current id */
-  nid = 0x8000 | (info->fileID + 1);
-  id  = 0xFFFF;
+  /* EFS supports file names only, without directory components. */
+  fn = file_name_validate (fn);
+  if (fn == NULL) {
+    return (fsInvalidPath);
+  }
 
-  /* Scan through all blocks */
-  for (block = 0; block < vol->SectorCount; block++) {
-    /* Read block signature */
-    addr = 0U;
+  pattern_len = fs_strlen (fn);
+  prefix_len  = fs_strpos (fn, '*');
+  suffix_len  = 0U;
 
-    stat = sign_read (vol, block, &fa.end, &addr);
-    if (stat != fsOK) {
-      return (stat);
-    }
+  if ((prefix_len >= 0) && (strcmp (&fn[prefix_len + 1], ".*") != 0)) {
+    /* Calculate the length of the suffix after the '*' character. */
+    suffix_len = pattern_len - (uint32_t)(prefix_len + 1);
+  }
 
-    /* Read all file allocation info */
-    prev = 0;
-    while (fa.end != vol->ErasedValue) {
-      stat = falloc_read (vol, addr, &fa, &addr);
+  for (;;) {
+    /* Initialize next and current id */
+    nid      = 0x8000 | (info->fileID + 1);
+    id       = 0xFFFF;
+    id_block = 0U;
+    fn_addr  = 0U;
 
+    /* Scan through all blocks */
+    for (block = 0; block < vol->SectorCount; block++) {
+      /* Read block signature */
+      addr = 0U;
+
+      stat = sign_read (vol, block, &fa.end, &addr);
       if (stat != fsOK) {
         return (stat);
       }
 
-      if (fa.end != vol->ErasedValue) {
-        if ((fa.fileID >= nid) && (fa.fileID < id)) {
-          /* Store the ID of the current valid file */
-          id = fa.fileID;
-          /* Store the block where we found the file */
-          id_block = block;
-          /* Store the file name address */
-          fn_addr = addr_of_block(vol, block) + prev;
+      /* Read all file allocation info */
+      prev = 0;
+      while (fa.end != vol->ErasedValue) {
+        stat = falloc_read (vol, addr, &fa, &addr);
 
-          if (id == nid) {
-            break;
-          }
+        if (stat != fsOK) {
+          return (stat);
         }
-        prev = fa.end;
+
+        if (fa.end != vol->ErasedValue) {
+          if ((fa.fileID >= nid) && (fa.fileID < id)) {
+            /* Store the ID of the current valid file */
+            id = fa.fileID;
+            /* Store the block where we found the file */
+            id_block = block;
+            /* Store the file name address */
+            fn_addr = addr_of_block(vol, block) + prev;
+
+            if (id == nid) {
+              break;
+            }
+          }
+          prev = fa.end;
+        }
       }
+
+      if (id == nid) { break; }
     }
 
-    if (id == nid) { break; }
+    if (id == 0xFFFF) {
+      /* File not found */
+      EvrFsEFS_FileNotFound (vol->DrvLet);
+      return (fsFileNotFound);
+    }
+
+    /* Filename is stored 4-byte aligned. */
+    fn_addr = (fn_addr + 3U) & ~3U;
+    /* Copy name to buffer. */
+    block_read (vol, fn_addr, &info->name, 32);
+
+    info->fileID = id & 0x7FFF;
+
+    /* Timestamps are not supported in EFS */
+    info->time.hr  = 12;
+    info->time.min = 0;
+    info->time.sec = 0;
+    info->time.day = 1;
+    info->time.mon = 1;
+    info->time.year= 1980;
+
+    info->size   = file_size_get (vol, id_block, info->fileID);
+    info->attrib = 0;
+
+    if (prefix_len >= 0) {
+      if (fs_strmatch (fn, info->name, (uint32_t)prefix_len, suffix_len) == 0U) {
+        return (fsOK);
+      }
+    }
+    else if ((fs_strlen (info->name) == pattern_len) &&
+             (fs_strncasecmp (info->name, fn, pattern_len) == 0U)) {
+      return (fsOK);
+    }
   }
-  
-  if (id == 0xFFFF) {
-    /* File not found */
-    EvrFsEFS_FileNotFound (vol->DrvLet);
-    return (fsFileNotFound);
-  }
-
-  /* Filename is stored 4-byte aligned. */
-  fn_addr = (fn_addr + 3U) & ~3U;
-  /* Copy name to buffer. */
-  block_read (vol, fn_addr, &info->name, 32);
-
-  info->fileID = id & 0x7FFF;
-
-  /* Timestamps are not supported in EFS */
-  info->time.hr  = 12;
-  info->time.min = 0;
-  info->time.sec = 0;
-  info->time.day = 1;
-  info->time.mon = 1;
-  info->time.year= 1980;
-  
-  info->size   = file_size_get (vol, id_block, info->fileID);
-  info->attrib = 0;
-
-  return (fsOK);
 }
 
 

--- a/Components/FileSystem/Source/fs_efs.c
+++ b/Components/FileSystem/Source/fs_efs.c
@@ -2286,8 +2286,8 @@ __WEAK fsStatus efs_ffind (const char *fn, fsFileInfo *info, fsEFS_Volume *vol) 
   uint32_t suffix_len;
   uint32_t pattern_len;
 
-  if (info == NULL) {
-    /* Invalid parameter */
+  if ((fn == NULL) || (info == NULL)) {
+    /* Invalid parameters */
     EvrFsEFS_InvalidParameter (vol->DrvLet);
     return (fsInvalidParameter);
   }

--- a/Components/FileSystem/Source/fs_fat.c
+++ b/Components/FileSystem/Source/fs_fat.c
@@ -5745,16 +5745,21 @@ __WEAK fsStatus fat_delete (const char *path, const char *options, fsFAT_Volume 
 
 
 /**
-  Find a file or directory in requested directory.
+  Find a file or directory matching the requested pattern.
 
-  \param[in]  fn                        path name
+  \param[in]  fn                        path and search pattern
   \param[out] info                      file information structure
   \param[in]  vol                       volume description structure
   \return     execution status \ref fsStatus
 */
 __WEAK fsStatus fat_ffind (const char *fn, fsFileInfo *info, fsFAT_Volume *vol) {
   PATH_INFO pinfo;
+  const char *pattern;
   fsStatus  status;
+  int32_t  prefix_len;
+  uint32_t suffix_len;
+  uint32_t pattern_len;
+  uint32_t i;
 
   if ((fn == NULL) || (info == NULL)) {
     /* Invalid parameters */
@@ -5770,11 +5775,37 @@ __WEAK fsStatus fat_ffind (const char *fn, fsFileInfo *info, fsFAT_Volume *vol) 
     return (status);
   }
 
-  path_init (fn, &pinfo, vol);
+  pattern = fn;
+  i       = 0U;
 
-  status = path_open (&pinfo, vol);
+  while (fn[i] != '\0') {
+    if ((fn[i] == '\\') || (fn[i] == '/')) {
+      pattern = &fn[i + 1U];
+    }
+    i++;
+  }
 
-  if (status == fsOK) {
+  if (*pattern == '\0') {
+    return (fsInvalidParameter);
+  }
+
+  pattern_len = fs_strlen (pattern);
+  prefix_len  = fs_strpos (pattern, '*');
+  suffix_len  = 0U;
+
+  if ((prefix_len >= 0) && (strcmp (&pattern[prefix_len + 1], ".*") != 0)) {
+    suffix_len = pattern_len - (uint32_t)(prefix_len + 1);
+  }
+
+  for (;;) {
+    path_init (fn, &pinfo, vol);
+
+    status = path_open (&pinfo, vol);
+
+    if (status != fsOK) {
+      return (status);
+    }
+
     if (pinfo.fn_flags & FAT_NAME_WILDCARD) {
       /* Reposition entry offset */
       pinfo.frec.pos.Clus = pinfo.dir_clus;
@@ -5809,8 +5840,17 @@ __WEAK fsStatus fat_ffind (const char *fn, fsFileInfo *info, fsFAT_Volume *vol) 
 
     extract_date (pinfo.sfne->WriteDate, &info->time);
     extract_time (pinfo.sfne->WriteTime, &info->time);
+
+    if (prefix_len >= 0) {
+      if (fs_strmatch (pattern, info->name, (uint32_t)prefix_len, suffix_len) == 0U) {
+        return (fsOK);
+      }
+    }
+    else if ((fs_strlen (info->name) == pattern_len) &&
+             (fs_strncasecmp (info->name, pattern, pattern_len) == 0U)) {
+      return (fsOK);
+    }
   }
-  return (status);
 }
 
 

--- a/Components/FileSystem/Source/fs_fat.c
+++ b/Components/FileSystem/Source/fs_fat.c
@@ -5766,9 +5766,6 @@ __WEAK fsStatus fat_ffind (const char *fn, fsFileInfo *info, fsFAT_Volume *vol) 
     EvrFsFAT_InvalidParameter (vol->DrvLet);
     return (fsInvalidParameter);
   }
-  if (*fn == '\0') {
-    return (fsInvalidPath);
-  }
 
   status = fat_vol_chk (FAT_STATUS_READY | FAT_STATUS_MOUNT, vol);
   if (status != fsOK) {
@@ -5786,7 +5783,7 @@ __WEAK fsStatus fat_ffind (const char *fn, fsFileInfo *info, fsFAT_Volume *vol) 
   }
 
   if (*pattern == '\0') {
-    return (fsInvalidParameter);
+    return (fsInvalidPath);
   }
 
   pattern_len = fs_strlen (pattern);

--- a/Components/FileSystem/Source/fs_mapi.c
+++ b/Components/FileSystem/Source/fs_mapi.c
@@ -288,12 +288,7 @@ fsStatus funmount (const char *drive) {
 */
 fsStatus ffind (const char *pattern, fsFileInfo *info) {
   FS_DEV *dev;
-  fsStatus retv;
   int32_t id;
-  const char *p;
-  int32_t  len1;
-  uint32_t len2;
-  uint32_t pattern_len;
 
   START_LOCK (fsStatus);
 
@@ -306,75 +301,17 @@ fsStatus ffind (const char *pattern, fsFileInfo *info) {
   }
   dev = &fs_DevPool[id];
 
-  len2 = 0U;
-  p    = pattern;
-
-  /* Strip out path from search pattern */
-  while (pattern[len2] != '\0') {
-    if ((pattern[len2] == '\\') || (pattern[len2] == '/')) {
-      p = &pattern[len2+1];
-    }
-    len2++;
-  }
-
-  if (*p == '\0') {
-    /* Invalid input (only directory path specified) */
-    RETURN (fsInvalidParameter);
-  }
-
-  pattern_len = fs_strlen (p);
-  len1        = fs_strpos (p, '*');
-
-  if (len1 >= 0) {
-    /* Wildcard found */
-    if (strcmp (&p[len1+1],".*") == 0) {
-      /* Search using *.* */
-      len2 = 0U;
-    }
-    else {
-      len2  = pattern_len;
-      len2 -= (uint32_t)(len1 + 1);
-    }
-  }
-
   if (dev->attr & FS_FAT) {
     /* Lock FAT volume */
     VOLUME_LOCK ((fsFAT_Volume *)dev->dcb);
+
+    RETURN (fat_ffind (pattern, info, (fsFAT_Volume *)dev->dcb));
   }
   else {
     /* Lock EFS volume */
     VOLUME_LOCK ((fsEFS_Volume *)dev->dcb);
-  }
 
-  for (;;) {
-    if (dev->attr & FS_FAT) {
-      /* Find FAT file */
-      retv = fat_ffind (pattern, info, (fsFAT_Volume *)dev->dcb);
-    }
-    else {
-      /* Find EFS file */
-      retv = efs_ffind (info, (fsEFS_Volume *)dev->dcb);
-    }
-
-    if (retv != fsOK) {
-      RETURN (retv);
-    }
-
-    if (len1 >= 0) {
-      /* Wildcard search, do partial compare */
-      if (fs_strmatch (&p[0], &info->name[0], (uint32_t)len1, len2) == 0) {
-        /* Partial match */
-        RETURN (fsOK);
-      }
-    }
-    else {
-      /* No wildcard, must exactly match (case insensitive) */
-      if ((fs_strlen (info->name) == pattern_len) &&
-          (fs_strncasecmp (&info->name[0], &p[0], pattern_len) == 0)) {
-        /* Exact match */
-        RETURN (fsOK);
-      }
-    }
+    RETURN (efs_ffind (pattern, info, (fsEFS_Volume *)dev->dcb));
   }
 
   END_LOCK;

--- a/Documentation/Doxygen/FileSystem/src/rl_fs.txt
+++ b/Documentation/Doxygen/FileSystem/src/rl_fs.txt
@@ -282,8 +282,9 @@ If file or directory matching to the specified pattern is found, \ref fsOK statu
 and time stamps are returned to the info structure. Status code \ref fsFileNotFound is returned when function fails to find any
 file or directory that matches to the specified pattern.
 
-If arguments \a pattern or \a info are NULL or if \a pattern specifies only directory path (i.e. ends with slash or backslash) 
-the \ref fsInvalidParameter status code is returned.  
+If arguments \a pattern or \a info are NULL, the \ref fsInvalidParameter status code is returned.
+If \a pattern is an empty string or specifies only a directory path (i.e. ends with a slash or backslash),
+the \ref fsInvalidPath status code is returned.
 
 Member \b fileID of the fsFileInfo structure is used to control the file search and must be <b>set to 0 (zero) before starting a new search</b>.
 


### PR DESCRIPTION
- moves search path/pattern processing and comparison to corresponding EFS/FAT module