### PR TITLE
USB Device: improve HID idle handling

### DIFF
--- a/Components/USB/Include/rl_usb.h
+++ b/Components/USB/Include/rl_usb.h
@@ -16,7 +16,7 @@
 
 #define MW_USB_VERSION_MAJOR           (8U)
 #define MW_USB_VERSION_MINOR           (0U)
-#define MW_USB_VERSION_PATCH           (2U)
+#define MW_USB_VERSION_PATCH           (3U)
 #define MW_USB_VERSION                ((MW_USB_VERSION_MAJOR * 10000000U) + \
                                        (MW_USB_VERSION_MINOR * 10000U)    + \
                                        (MW_USB_VERSION_PATCH))

--- a/Components/USB/Source/usbd_config.c
+++ b/Components/USB/Source/usbd_config.c
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2024-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    usbd_config.c
  * Purpose: USB Devices (0..3) Configuration

--- a/Components/USB/Source/usbd_lib.h
+++ b/Components/USB/Source/usbd_lib.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    usbd_lib.h
  * Purpose: USB Device header file
@@ -272,7 +272,7 @@ typedef struct {
   uint16_t              data_in_rece_len;                   ///< length of received data
   uint16_t              data_feat_rece_len;                 ///< length of received feature data
   bool                  data_out_end_with_zlp_packet;       ///< data send ended with Zero Length Packet (ZLP) flag
-  uint8_t               last_in_report;                     ///< last input report index if multiple input reports are specified"
+  uint8_t               last_in_report;                     ///< last input report index if multiple input reports are specified
   uint8_t               pad0[2];                            ///< explicit padding
 } usbd_hid_data_t;
 

--- a/Components/USB/Source/usbd_lib_hid.c
+++ b/Components/USB/Source/usbd_lib_hid.c
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
  * MDK Middleware - Component ::USB:Device
- * Copyright (c) 2004-2024 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2004-2026 Arm Limited (or its affiliates). All rights reserved.
  *------------------------------------------------------------------------------
  * Name:    usbd_lib_hid.c
  * Purpose: USB Device - Human Interface Device (HID) module
@@ -472,6 +472,8 @@ void USBD_HID_EndpointStart (uint8_t instance, uint8_t ep_addr) {
 }
 
 /// \brief HID Timer event handling (handling report timings: polling and idle times)(called every 4 ms).
+/// \details       The timer interval is 4 ms, as this is the resolution of the idle duration defined by the HID specification
+///                (HID1_11.pdf, 7.2.4 Set_Idle Request)
 /// \param[in]     instance      instance of HID class.
 void USBD_HID_Timer (void const *argument) {
   const usbd_data_t     *ptr_dev_data;
@@ -498,17 +500,17 @@ void USBD_HID_Timer (void const *argument) {
       if (ptr_hid_cfg->ep_int_in_interval[1] == 0U) {
         polling_interval = 1U;
       } else {
-        polling_interval = INTERVAL_HS[ptr_hid_cfg->ep_int_in_interval[1]-1U];
+        polling_interval = INTERVAL_HS[(ptr_hid_cfg->ep_int_in_interval[1]-1U) & 0x0FU];
       }
     } else {
       if (ptr_hid_cfg->ep_int_in_interval[0] == 0U) {
         polling_interval = 1U;
       } else {
-        polling_interval = ptr_hid_cfg->ep_int_in_interval[0];
+        polling_interval = ptr_hid_cfg->ep_int_in_interval[0] & 0xFFU;
       }
     }
     polling_reload = false;
-    if (ptr_hid_data->polling_count == polling_interval) {
+    if (ptr_hid_data->polling_count >= polling_interval) {
       ptr_hid_data->polling_count = 0U;
       polling_reload = true;            // If polling interval expired
     }
@@ -546,8 +548,6 @@ void USBD_HID_Timer (void const *argument) {
       if (USBD_SemaphoreAcquire (usbd_hid_semaphore_id[instance], 0U) == 0) {
         USBD_HID_EpIntIn (instance);
       }
-    } else {
-      ptr_hid_data->data_out_update_req_mask &= ~(1UL << i);
     }
   }
 }
@@ -627,11 +627,7 @@ static void USBD_HID_EpIntIn (uint8_t instance) {
             ptr_hid_data->data_out_update_req_mask  = 0U;
           }
         } else {                        // If multiple reports in system
-          i = ptr_hid_data->last_in_report + 1U;
-          do {
-            if (i > ptr_hid_cfg->in_report_num) {
-              i = 0U;
-            }
+          for (i = 0U; i < ptr_hid_cfg->in_report_num; i++) {
             if ((ptr_hid_data->data_out_update_req_mask & (1UL << i)) != 0U) {
               ptr_hid_cfg->in_report[0]= i + 1U;        // ReportID
               ptr_hid_data->data_out_sent_len    = 0U;
@@ -646,7 +642,7 @@ static void USBD_HID_EpIntIn (uint8_t instance) {
               ptr_hid_data->data_out_update_req_mask &= ~(1UL << i);
               break;
             }
-          } while (i != ptr_hid_data->last_in_report);
+          }
         }
       }
     }

--- a/Components/USB/USB.scvd
+++ b/Components/USB/USB.scvd
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <component_viewer schemaVersion="0.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="Component_Viewer.xsd">
-  <component name="USB Device/Host" shortname="USBD/H" version="8.0.2"/>        <!-- name and version of the component  -->
+  <component name="USB Device/Host" shortname="USBD/H" version="8.0.3"/>        <!-- name and version of the component  -->
 
   <typedefs>
     <!-- USB Generic Typedefs ************************************************************************************************ -->

--- a/Documentation/Doxygen/USB/src/revision_history.md
+++ b/Documentation/Doxygen/USB/src/revision_history.md
@@ -6,6 +6,14 @@
       <th>Description</th>
     </tr>
     <tr>
+      <td>V8.0.3</td>
+      <td>
+        - USB Device: updated HID configuration for high-speed interrupt endpoints
+        - USB Device: fixed HID idle handling for endpoint intervals not aligned to 4 ms
+        - USB Device: fixed HID idle handling for multiple input reports
+      </td>
+    </tr>
+    <tr>
       <td>V8.0.2</td>
       <td>
         - USB Host: improve code robustness

--- a/Keil.MDK-Middleware.pdsc
+++ b/Keil.MDK-Middleware.pdsc
@@ -25,6 +25,8 @@
       Network Component Version 8.3.1
       - fixed possible TCP socket reset after timeout recovery
       - various minor fixes and security improvements
+      USB Component Version 8.0.3
+      - USB Device: improved HID idle handling
     </release>
     <release version="7.17.0" date="2024-01-17">
       Network Component Version 7.19.0
@@ -1267,7 +1269,7 @@
     </bundle>
 
     <!-- USB (MDK) -->
-    <bundle Cbundle="MDK" Cclass="USB" Cversion="8.0.2">
+    <bundle Cbundle="MDK" Cclass="USB" Cversion="8.0.3">
       <description>USB Communication with various device classes</description>
       <doc>Documentation/html/USB/index.html</doc>
       <component Cgroup="CORE" condition="CMSIS Core with RTOS">


### PR DESCRIPTION
- fixed HID idle handling for endpoint intervals not aligned to 4 ms
- fixed HID idle handling for multiple input reports